### PR TITLE
Windows dll debug编译问题

### DIFF
--- a/hikyuu_cpp/hikyuu/xmake.lua
+++ b/hikyuu_cpp/hikyuu/xmake.lua
@@ -30,8 +30,8 @@ else
 end
 
 if is_plat("windows") then
-    add_defines("HKU_API=__declspec(dllexport)")
     if is_mode("release") then
+        add_defines("HKU_API=__declspec(dllexport)")
         add_packages("hdf5")
     else
         add_packages("hdf5_D")

--- a/hikyuu_cpp/hikyuu_server/xmake.lua
+++ b/hikyuu_cpp/hikyuu_server/xmake.lua
@@ -21,7 +21,9 @@ target("hkuserver")
     end
     
     if is_plat("windows") then 
-        add_defines("HKU_API=__declspec(dllimport)")
+        if is_mode("release") then
+            add_defines("HKU_API=__declspec(dllimport)")
+        end
         add_packages("mysql")
     end
     

--- a/hikyuu_cpp/unit_test/xmake.lua
+++ b/hikyuu_cpp/unit_test/xmake.lua
@@ -123,3 +123,8 @@ target("small-test")
 
     after_run(coverage_report)
 target_end()
+
+target("prepare-test")
+    set_kind("phony")
+    set_default(false)
+target_end()

--- a/hikyuu_pywrap/xmake.lua
+++ b/hikyuu_pywrap/xmake.lua
@@ -21,7 +21,7 @@ target("core")
         set_filename("core.so")
     end
 
-    if is_plat("windows") then
+    if is_plat("windows") and is_mode("release") then
         add_defines("HKU_API=__declspec(dllimport)")
         add_cxflags("-wd4566")
     end

--- a/scripts/before_run.lua
+++ b/scripts/before_run.lua
@@ -8,7 +8,7 @@ function main(target)
     if not with_demo then raise("You need to config first: xmake f --with-demo=y") end
   end
 
-  if "unit-test" == targetname or "small-test" == targetname then
+  if "unit-test" == targetname or "small-test" == targetname or "prepare-test" == targetname then
     print("copying test_data ...")
     os.rm("$(buildir)/$(mode)/$(plat)/$(arch)/lib/test_data")
     os.cp("$(projectdir)/test_data", "$(buildir)/$(mode)/$(plat)/$(arch)/lib/")

--- a/xmake.lua
+++ b/xmake.lua
@@ -65,6 +65,7 @@ end
 add_requires("myboost " .. boost_version, {
   system = false,
   alias = "boost",
+  debug = is_mode("debug"),
   configs = {
     shared = is_plat("windows") and true or false,
     data_time = true,


### PR DESCRIPTION
修复debug模式下编译定义HKU_API报link error的问题。
debug模式使用boost的debug build，不然跑unittest会因为boost直接core dump，而且vscode的testmate插件要依赖debug symbol从二进制文件里解析test case。