### PR TITLE
PR

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -120,6 +120,9 @@
 // 关闭 HKU_ASSERT
 #define HKU_DISABLE_ASSERT ${HKU_DISABLE_ASSERT}
 
+// 启用MSVC内存泄漏检查
+${define ENABLE_LEAK_DETECT}
+
 // clang-format on
 
 #endif /* HIKYUU_CONFIG_H_ */

--- a/hikyuu/indicator/pyind.py
+++ b/hikyuu/indicator/pyind.py
@@ -47,7 +47,7 @@ def KDJ(kdata=None, n=9, m1=3, m2=3):
     return k, d, j
 
 
-def RSI(kdata=None, N1=6, N2=12, N3=24):
+def RSI_PY(kdata=None, N1=6, N2=12, N3=24):
     """相对强弱指标
 
         :param KData kdata: 关联的K线数据

--- a/hikyuu_cpp/hikyuu/debug.h
+++ b/hikyuu_cpp/hikyuu/debug.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#if defined(_MSC_VER) && (defined(_DEBUG) || defined(DEBUG))
+#if defined(_MSC_VER) && (defined(_DEBUG) || defined(DEBUG)) && defined(ENABLE_LEAK_DETECT)
 #ifndef MSVC_LEAKER_DETECT
 #define MSVC_LEAKER_DETECT
 #endif

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -344,7 +344,7 @@ string IndicatorImp::formula() const {
             break;
 
         case SUB:
-            buf << m_left->formula() << " + " << m_right->formula();
+            buf << m_left->formula() << " - " << m_right->formula();
             break;
 
         case MUL:
@@ -454,6 +454,27 @@ void IndicatorImp::add(OPType op, IndicatorImpPtr left, IndicatorImpPtr right) {
                     m_right->m_right = right->clone();
                 } else {
                     m_right->add(OP, left, right);
+                }
+            }
+        }
+        if (m_three) {
+            if (m_three->isNeedContext()) {
+                if (m_three->isLeaf()) {
+                    m_need_calculate = true;
+                    m_three = right->clone();
+                } else {
+                    HKU_WARN(
+                      "Context-dependent indicator can only be at the leaf node!"
+                      "parent node: {}, try add node: {}",
+                      name(), right->name());
+                }
+            } else {
+                if (m_three->isLeaf()) {
+                    m_three->m_need_calculate = true;
+                    m_three->m_optype = op;
+                    m_three->m_right = right->clone();
+                } else {
+                    m_three->add(OP, left, right);
                 }
             }
         }

--- a/hikyuu_cpp/hikyuu/indicator/build_in.h
+++ b/hikyuu_cpp/hikyuu/indicator/build_in.h
@@ -74,6 +74,7 @@
 #include "crt/ROUND.h"
 #include "crt/ROUNDDOWN.h"
 #include "crt/ROUNDUP.h"
+#include "crt/RSI.h"
 #include "crt/SAFTYLOSS.h"
 #include "crt/SIN.h"
 #include "crt/SLICE.h"

--- a/hikyuu_cpp/hikyuu/indicator/crt/RSI.h
+++ b/hikyuu_cpp/hikyuu/indicator/crt/RSI.h
@@ -1,0 +1,39 @@
+/*
+ * RSI.h
+ * 
+ *   Created on: 2023年09月23日
+ *       Author: yangrq1018
+ */
+#pragma once
+#ifndef INDICATOR_CRT_RSI_H_
+#define INDICATOR_CRT_RSI_H_
+
+#include "../Indicator.h"
+#include "REF.h"
+#include "EMA.h"
+#include "CVAL.h"
+
+namespace hku {
+
+/**
+ * 相对强弱指数
+ * @ingroup Indicator
+ */
+Indicator HKU_API RSI(int n = 14) {
+    Indicator diff = REF(0) - REF(1);
+    Indicator u = IF(diff > 0, diff, 0);
+    Indicator d = IF(diff < 0, (-1) * diff, 0);
+    Indicator ema_u = EMA(u, n);
+    Indicator ema_d = EMA(d, n);
+    Indicator rs = ema_u / ema_d;
+    Indicator _1 = CVAL(1);
+    Indicator rsi = (_1 - _1 / (_1 + rs)) * CVAL(100);
+    rsi.name("RSI");
+    rsi.setParam<int>("n", n);
+    return rsi;
+}
+
+}  // namespace hku
+
+#endif /* INDICATOR_CRT_ABS_H_ */
+

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/build_in.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/build_in.h
@@ -14,5 +14,6 @@
 #include "crt/SG_Flex.h"
 #include "crt/SG_Single.h"
 #include "crt/SG_Bool.h"
+#include "crt/SG_Band.h"
 
 #endif /* SIGNAL_BUILD_IN_H_ */

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/crt/SG_Band.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/crt/SG_Band.h
@@ -1,0 +1,21 @@
+/*
+ * SG_Band.h
+ *
+ *   Created on: 2023年09月23日
+ *       Author: yangrq1018
+ */
+#pragma once
+#ifndef TRADE_SYS_SIGNAL_CRT_SG_BAND_H_
+#define TRADE_SYS_SIGNAL_CRT_SG_BAND_H_
+
+#include "../../../indicator/Indicator.h"
+#include "../SignalBase.h"
+
+namespace hku {
+
+SignalPtr HKU_API SG_Band(const Indicator& sig, price_t lower, price_t upper,
+                          const string& kpart = "CLOSE");
+
+} /* namespace hku */
+
+#endif /* TRADE_SYS_SIGNAL_CRT_SG_BOOL_H_ */

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BandSignal.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BandSignal.cpp
@@ -1,0 +1,54 @@
+/*
+ * BandSignal.cpp
+ *
+ *   Created on: 2023年09月23日
+ *       Author: yangrq1018
+ */
+#include "../../../indicator/crt/KDATA.h"
+#include "BandSignal.h"
+
+namespace hku {
+
+BandSignal::BandSignal() : SignalBase("SG_Band") {
+    setParam<string>("kpart", "CLOSE");
+}
+
+BandSignal::BandSignal(const Indicator& ind, price_t lower, price_t upper, const string& kpart)
+: SignalBase("SG_Band"), m_ind(ind), m_lower(lower), m_upper(upper) {
+    setParam<string>("kpart", kpart);
+    HKU_ERROR_IF(m_lower > m_upper, "BandSignal: lower track is greater than upper track");
+}
+
+BandSignal::~BandSignal() {}
+
+SignalPtr BandSignal::_clone() {
+    BandSignal* p = new BandSignal();
+    p->m_upper = m_upper;
+    p->m_lower = m_lower;
+    p->m_ind = m_ind;
+    return SignalPtr(p);
+}
+
+void BandSignal::_calculate() {
+    string kpart = getParam<string>("kpart");
+    Indicator kdata = KDATA_PART(m_kdata, kpart);
+
+    Indicator ind = m_ind(kdata);
+    size_t discard = ind.discard();
+    size_t total = ind.size();
+
+    for (size_t i = discard; i < total; ++i) {
+        if (ind[i] > m_upper) {
+            _addBuySignal(m_kdata[i].datetime);
+        } else if (ind[i] < m_lower) {
+            _addSellSignal(m_kdata[i].datetime);
+        }
+    }
+}
+
+SignalPtr HKU_API SG_Band(const Indicator& sig, price_t lower, price_t upper,
+                          const string& kpart = "CLOSE") {
+    return SignalPtr(new BandSignal(sig, lower, upper, kpart));
+}
+
+}  // namespace hku

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BandSignal.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BandSignal.h
@@ -1,0 +1,32 @@
+/*
+ * BandSignal.h
+ *
+ *   Created on: 2023年09月23日
+ *       Author: yangrq1018
+ */
+
+#pragma once
+#ifndef TRADE_SYS_SIGNAL_IMP_BANDSIGNAL_H_
+#define TRADE_SYS_SIGNAL_IMP_BANDSIGNAL_H_
+
+#include "../../../indicator/Indicator.h"
+#include "../SignalBase.h"
+
+namespace hku {
+
+class BandSignal : public SignalBase {
+public:
+    BandSignal();
+    BandSignal(const Indicator& sig, price_t lower, price_t upper, const string& kpart); 
+    virtual ~BandSignal();
+
+    virtual SignalPtr _clone() override;
+    virtual void _calculate() override;
+
+private:
+    Indicator m_ind;
+    price_t m_lower, m_upper;
+};
+}  // namespace hku
+
+#endif

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BoolSignal.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BoolSignal.cpp
@@ -16,7 +16,7 @@ BoolSignal::BoolSignal() : SignalBase("SG_Bool") {
 
 BoolSignal::BoolSignal(const Indicator& buy, const Indicator& sell, const string& kpart)
 : SignalBase("SG_Bool"), m_bool_buy(buy), m_bool_sell(sell) {
-    setParam<string>("kpart", "CLOSE");
+    setParam<string>("kpart", kpart);
 }
 
 BoolSignal::~BoolSignal() {}

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_IF.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_IF.cpp
@@ -10,6 +10,7 @@
 #include <hikyuu/StockManager.h>
 #include <hikyuu/indicator/crt/KDATA.h>
 #include <hikyuu/indicator/crt/CVAL.h>
+#include <hikyuu/indicator/crt/REF.h>
 
 using namespace hku;
 
@@ -34,6 +35,17 @@ TEST_CASE("test_IF") {
         } else {
             CHECK_EQ(x[i], 0);
         }
+    }
+
+    /** @arg 测试调用operator()(const Indicator&) */
+    x = IF(REF(0) > REF(1), 1, 0);
+    c = CLOSE(kdata);
+    x = x(c);
+    for (int i = 0; i < x.size(); i++) {
+        if (i == 0)
+            CHECK(std::isnan(x[i]));
+        else
+            CHECK_EQ(x[i], c[i] > c[i-1] ? 1 : 0);
     }
 
     /** @arg 参数其中之一为数字 */

--- a/hikyuu_pywrap/indicator/_build_in.cpp
+++ b/hikyuu_pywrap/indicator/_build_in.cpp
@@ -426,6 +426,8 @@ Indicator (*SLICE_1)(const PriceList&, int64_t, int64_t) = SLICE;
 Indicator (*SLICE_2)(int64_t, int64_t, int) = SLICE;
 Indicator (*SLICE_3)(const Indicator&, int64_t, int64_t, int) = SLICE;
 
+Indicator (*RSI_1)(int) = RSI;
+
 void export_Indicator_build_in() {
     def("KDATA", KDATA1);
     def("KDATA", KDATA3, R"(KDATA([data])
@@ -1479,4 +1481,13 @@ void export_Indicator_build_in() {
     :param int start: 起始位置
     :param int end: 终止位置（不包含本身）
     :param int result_index: 原输入数据中的结果集)");
+
+    def("RSI", RSI_1, (arg("n") = 14), R"(RSI([data, n=14])
+
+    相对强弱指数
+
+    :param Indicator data: 输入数据
+    :param int|Indicator|IndParam n: 时间窗口
+    :rtype: Indicator)");
+
 }

--- a/hikyuu_pywrap/trade_sys/_Signal.cpp
+++ b/hikyuu_pywrap/trade_sys/_Signal.cpp
@@ -222,4 +222,12 @@ void export_Signal() {
     :param int slow_n: 慢线EMA周期
     :param string kpart: KDATA|OPEN|HIGH|LOW|CLOSE|AMO|VOL
     :return: 信号指示器)");
+
+    def ("SG_Band", SG_Band, (arg("ind"), arg("lower"), arg("upper"), arg("kpart") = "CLOSE"),
+      R"(SG_Band(ind, lower, upper[, kpart = 'CLOSE'])
+    指标区间指示器, 当指标超过上轨时，买入；
+    当指标低于下轨时，卖出。::
+
+        SG_Band(OP(MA(n=10)), 100, 200)
+      )");
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -27,6 +27,7 @@ set_configvar("SUPPORT_TEXT_ARCHIVE", 0)
 set_configvar("SUPPORT_XML_ARCHIVE", 1)
 set_configvar("SUPPORT_BINARY_ARCHIVE", 1)
 set_configvar("HKU_DISABLE_ASSERT", 0)
+set_configvar("ENABLE_LEAK_DETECT", true)
 
 -- set warning all as error
 if is_plat("windows") then


### PR DESCRIPTION
- 增加了一个config var `ENABLE_LEAK_DETECT`，默认是开启内存泄漏检测的。跑单测的时候core dump出来太多行了，测试的输出直接被刷没了，我这时候希望把内存泄漏检测关掉，只需要在xmake.lua里把设置成false，改这一个地方就行。
- 添加了`BandSignal`信号，可用于区间突破类的策略。
- 在cpp端实现RSI指标，我看了下跟`pyind.py`里的RSI大致是一样的，我参考的[Wiki](https://zh.wikipedia.org/zh-hans/%E7%9B%B8%E5%B0%8D%E5%BC%B7%E5%BC%B1%E6%8C%87%E6%95%B8)定义，主要的区别是SMA换成EMA。Python indicator的引入顺序在cpp indicator的后面，所以python优先级比较高会覆盖同名的变量，我修改了python端的函数名避免覆盖。
- 麻烦看下`test_IF`新增的这个测试用例，`IndicatorImp`的实现似乎有点问题，会导致IF OP的失效，我尝试修了下，不确定有没有问题。这也是在写RSI的时候发现的。
- 一些typo改正