### PR TITLE
Update IndicatorImp.cpp

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -113,7 +113,7 @@ void IndicatorImp::initContext() {
 
 void IndicatorImp::setContext(const Stock &stock, const KQuery &query) {
     KData kdata = getContext();
-    if (kdata.getStock() == stock || kdata.getQuery() == query) {
+    if (kdata.getStock() == stock && kdata.getQuery() == query) {
         if (m_need_calculate) {
             calculate();
         }


### PR DESCRIPTION
修正void IndicatorImp::setContext(const Stock &stock, const KQuery &query)中是否修改Context的判断逻辑，原逻辑为stock或quey有一项没有改动就不修改Context，在遍历时，这个逻辑会导致Context永远为第一个设置的Context