### PR TITLE
Short sell update and several changes

### DIFF
--- a/hikyuu/examples/notebook/011-PyechartsDrawplot.ipynb
+++ b/hikyuu/examples/notebook/011-PyechartsDrawplot.ipynb
@@ -76,7 +76,7 @@
     "my_tm = crtTM(init_cash = 300000)\n",
     "\n",
     "#创建信号指示器（相对强弱信号）\n",
-    "ind = RSI(24)\n",
+    "ind = RSI(C, 24)\n",
     "my_sg = SG_Band(ind, 30, 70)\n",
     "\n",
     "#固定每次买入1股\n",

--- a/hikyuu/trade_manage/broker.py
+++ b/hikyuu/trade_manage/broker.py
@@ -30,7 +30,6 @@
 #===============================================================================
 
 from hikyuu import OrderBrokerBase
-from hikyuu import Datetime
 
 
 class OrderBrokerWrap(OrderBrokerBase):

--- a/hikyuu_cpp/hikyuu/data_driver/kdata/sqlite/SQLiteKDataDriver.cpp
+++ b/hikyuu_cpp/hikyuu/data_driver/kdata/sqlite/SQLiteKDataDriver.cpp
@@ -33,7 +33,7 @@ inline KQuery::KType getBaseKType(const KQuery::KType& ktype) {
     return base_ktype;
 }
 
-SQLiteKDataDriver::SQLiteKDataDriver() : KDataDriver("sqlite") {}
+SQLiteKDataDriver::SQLiteKDataDriver() : KDataDriver("sqlite3") {}
 
 SQLiteKDataDriver::~SQLiteKDataDriver() {}
 

--- a/hikyuu_cpp/hikyuu/debug.h
+++ b/hikyuu_cpp/hikyuu/debug.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#if ENABLE_LEAK_DETECT && defined(_MSC_VER) && (defined(_DEBUG) || defined(DEBUG))
+#if ENABLE_MSVC_LEAK_DETECT && defined(_MSC_VER) && (defined(_DEBUG) || defined(DEBUG))
 #ifndef MSVC_LEAKER_DETECT
 #define MSVC_LEAKER_DETECT
 #endif

--- a/hikyuu_cpp/hikyuu/indicator/crt/RSI.h
+++ b/hikyuu_cpp/hikyuu/indicator/crt/RSI.h
@@ -35,4 +35,5 @@ Indicator RSI(int n = 14) {
 
 }  // namespace hku
 
-#endif /* INDICATOR_CRT_ABS_H_ */
+#endif /* INDICATOR_CRT_RSI_H_ */
+

--- a/hikyuu_cpp/hikyuu/indicator/crt/RSI.h
+++ b/hikyuu_cpp/hikyuu/indicator/crt/RSI.h
@@ -33,6 +33,10 @@ Indicator RSI(int n = 14) {
     return rsi;
 }
 
+Indicator RSI(const Indicator& data, int n) {
+    return RSI(n)(data);
+}
+
 }  // namespace hku
 
 #endif /* INDICATOR_CRT_RSI_H_ */

--- a/hikyuu_cpp/hikyuu/trade_sys/moneymanager/MoneyManagerBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/moneymanager/MoneyManagerBase.cpp
@@ -175,7 +175,8 @@ double MoneyManagerBase::_getSellShortNumber(const Datetime& datetime, const Sto
 
 double MoneyManagerBase::_getBuyShortNumber(const Datetime& datetime, const Stock& stock,
                                             price_t price, price_t risk, SystemPart from) {
-    return 0;
+    // 默认全部平仓
+    return MAX_DOUBLE;
 }
 
 } /* namespace hku */

--- a/hikyuu_cpp/hikyuu/trade_sys/moneymanager/imp/FixedCountMoneyManager.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/moneymanager/imp/FixedCountMoneyManager.cpp
@@ -20,6 +20,11 @@ double FixedCountMoneyManager ::_getBuyNumber(const Datetime& datetime, const St
     return getParam<double>("n");
 }
 
+double FixedCountMoneyManager::_getSellShortNumber(const Datetime& datetime, const Stock& stock,
+                                                   price_t price, price_t risk, SystemPart from) {
+    return getParam<double>("n");
+}
+
 MoneyManagerPtr HKU_API MM_FixedCount(double n) {
     FixedCountMoneyManager* p = new FixedCountMoneyManager();
     p->setParam<double>("n", n);

--- a/hikyuu_cpp/hikyuu/trade_sys/moneymanager/imp/FixedCountMoneyManager.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/moneymanager/imp/FixedCountMoneyManager.h
@@ -23,6 +23,9 @@ namespace hku {
  */
 class FixedCountMoneyManager : public MoneyManagerBase {
     MONEY_MANAGER_IMP(FixedCountMoneyManager)
+
+    virtual double _getSellShortNumber(const Datetime& datetime, const Stock& stock, price_t price,
+                                       price_t risk, SystemPart from) override;
     MONEY_MANAGER_NO_PRIVATE_MEMBER_SERIALIZATION
 
 public:

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp
@@ -26,12 +26,12 @@ HKU_API std::ostream& operator<<(std::ostream& os, const SignalPtr& sg) {
 
 SignalBase::SignalBase() : m_name("SignalBase"), m_hold_long(false), m_hold_short(false) {
     setParam<bool>("alternate", true);       // 买入卖出信号交替出现
-    setParam<bool>("support-short", false);  // 支持发出空头信号
+    setParam<bool>("support_borrow_stock", false);  // 支持发出空头信号
 }
 
 SignalBase::SignalBase(const string& name) : m_name(name), m_hold_long(false), m_hold_short(false) {
     setParam<bool>("alternate", true);
-    setParam<bool>("support-short", false);
+    setParam<bool>("support_borrow_stock", false);
 }
 
 SignalBase::~SignalBase() {}
@@ -93,7 +93,7 @@ void SignalBase::_addBuySignal(const Datetime& datetime) {
     } else {
         if (!m_hold_long) {
             m_buySig.insert(datetime);
-            if (getParam<bool>("support-short") && m_hold_short) {
+            if (getParam<bool>("support_borrow_stock") && m_hold_short) {
                 m_hold_short = false;
             } else {
                 m_hold_long = true;
@@ -110,7 +110,7 @@ void SignalBase::_addSellSignal(const Datetime& datetime) {
             if (m_hold_long) {
                 m_sellSig.insert(datetime);
                 m_hold_long = false;
-            } else if (getParam<bool>("support-short")) {
+            } else if (getParam<bool>("support_borrow_stock")) {
                 m_sellSig.insert(datetime);
                 m_hold_short = true;
             }

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp
@@ -24,12 +24,14 @@ HKU_API std::ostream& operator<<(std::ostream& os, const SignalPtr& sg) {
     return os;
 }
 
-SignalBase::SignalBase() : m_name("SignalBase"), m_hold(false) {
-    setParam<bool>("alternate", true);  //买入卖出信号交替出现
+SignalBase::SignalBase() : m_name("SignalBase"), m_hold_long(false), m_hold_short(false) {
+    setParam<bool>("alternate", true);       // 买入卖出信号交替出现
+    setParam<bool>("support-short", false);  // 支持发出空头信号
 }
 
-SignalBase::SignalBase(const string& name) : m_name(name), m_hold(false) {
+SignalBase::SignalBase(const string& name) : m_name(name), m_hold_long(false), m_hold_short(false) {
     setParam<bool>("alternate", true);
+    setParam<bool>("support-short", false);
 }
 
 SignalBase::~SignalBase() {}
@@ -51,7 +53,7 @@ SignalPtr SignalBase::clone() {
     p->m_name = m_name;
     p->m_params = m_params;
     p->m_kdata = m_kdata;
-    p->m_hold = m_hold;
+    p->m_hold_long = m_hold_long;
     p->m_buySig = m_buySig;
     p->m_sellSig = m_sellSig;
     return p;
@@ -68,7 +70,8 @@ void SignalBase::setTO(const KData& kdata) {
 void SignalBase::reset() {
     m_buySig.clear();
     m_sellSig.clear();
-    m_hold = false;
+    m_hold_long = false;
+    m_hold_short = false;
     _reset();
 }
 
@@ -88,9 +91,13 @@ void SignalBase::_addBuySignal(const Datetime& datetime) {
     if (!getParam<bool>("alternate")) {
         m_buySig.insert(datetime);
     } else {
-        if (!m_hold) {
+        if (!m_hold_long) {
             m_buySig.insert(datetime);
-            m_hold = true;
+            if (getParam<bool>("support-short") && m_hold_short) {
+                m_hold_short = false;
+            } else {
+                m_hold_long = true;
+            }
         }
     }
 }
@@ -99,9 +106,14 @@ void SignalBase::_addSellSignal(const Datetime& datetime) {
     if (!getParam<bool>("alternate")) {
         m_sellSig.insert(datetime);
     } else {
-        if (m_hold) {
-            m_sellSig.insert(datetime);
-            m_hold = false;
+        if (!m_hold_short) {
+            if (m_hold_long) {
+                m_sellSig.insert(datetime);
+                m_hold_long = false;
+            } else if (getParam<bool>("support-short")) {
+                m_sellSig.insert(datetime);
+                m_hold_short = true;
+            }
         }
     }
 }

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.h
@@ -134,7 +134,8 @@ private:
     void save(Archive& ar, const unsigned int version) const {
         ar& BOOST_SERIALIZATION_NVP(m_name);
         ar& BOOST_SERIALIZATION_NVP(m_params);
-        ar& BOOST_SERIALIZATION_NVP(m_hold);
+        ar& BOOST_SERIALIZATION_NVP(m_hold_long);
+        ar& BOOST_SERIALIZATION_NVP(m_hold_short);
         ar& BOOST_SERIALIZATION_NVP(m_buySig);
         ar& BOOST_SERIALIZATION_NVP(m_sellSig);
         // m_kdata都是系统运行时临时设置，不需要序列化
@@ -145,7 +146,8 @@ private:
     void load(Archive& ar, const unsigned int version) {
         ar& BOOST_SERIALIZATION_NVP(m_name);
         ar& BOOST_SERIALIZATION_NVP(m_params);
-        ar& BOOST_SERIALIZATION_NVP(m_hold);
+        ar& BOOST_SERIALIZATION_NVP(m_hold_long);
+        ar& BOOST_SERIALIZATION_NVP(m_hold_short);
         ar& BOOST_SERIALIZATION_NVP(m_buySig);
         ar& BOOST_SERIALIZATION_NVP(m_sellSig);
         // m_kdata都是系统运行时临时设置，不需要序列化

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.h
@@ -115,7 +115,10 @@ public:
 protected:
     string m_name;
     KData m_kdata;
-    bool m_hold;
+    /* 多头持仓 */
+    bool m_hold_long;
+    /* 空头持仓 */
+    bool m_hold_short;
 
     // 用 set 保存，以便获取是能保持顺序
     std::set<Datetime> m_buySig;

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BandSignal.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/imp/BandSignal.cpp
@@ -13,7 +13,7 @@ BandSignal::BandSignal() : SignalBase("SG_Band") {}
 
 BandSignal::BandSignal(const Indicator& ind, price_t lower, price_t upper)
 : SignalBase("SG_Band"), m_ind(ind), m_lower(lower), m_upper(upper) {
-    HKU_ERROR_IF(m_lower > m_upper, "BandSignal: lower track is greater than upper track");
+    HKU_ERROR_IF(lower > upper, "BandSignal: lower track is greater than upper track");
 }
 
 BandSignal::~BandSignal() {}

--- a/hikyuu_cpp/hikyuu/trade_sys/system/System.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/system/System.cpp
@@ -415,8 +415,11 @@ TradeRecord System::_runMoment(const KRecord& today, const KRecord& src_today) {
 
     //如果有买入信号
     if (m_sg->shouldBuy(today.datetime)) {
-        TradeRecord tr = _buy(today, src_today, PART_SIGNAL);
-        // if (m_tm->haveShort(m_stock)) _sellShort(today);
+        TradeRecord tr;
+        if (m_tm->haveShort(m_stock))
+            tr = _buyShort(today, src_today, PART_SIGNAL);
+        else
+            tr = _buy(today, src_today, PART_SIGNAL);
         return tr.isNull() ? result : tr;
     }
 
@@ -425,7 +428,8 @@ TradeRecord System::_runMoment(const KRecord& today, const KRecord& src_today) {
         TradeRecord tr;
         if (m_tm->have(m_stock))
             tr = _sell(today, src_today, PART_SIGNAL);
-        //_buyShort(today, PART_SIGNAL);
+        else
+            tr = _sellShort(today, src_today, PART_SIGNAL);
         return tr.isNull() ? result : tr;
     }
 
@@ -992,7 +996,7 @@ TradeRecord System::_sellShortDelay(const KRecord& today, const KRecord& src_tod
 
     price_t realPrice = _getRealSellPrice(today.datetime, planPrice);
 
-    TradeRecord record = m_tm->sell(today.datetime, m_stock, realPrice, number, stoploss, goalPrice,
+    TradeRecord record = m_tm->sellShort(today.datetime, m_stock, realPrice, number, stoploss, goalPrice,
                                     planPrice, m_sellShortRequest.from);
     if (BUSINESS_SELL_SHORT != record.business) {
         m_sellShortRequest.clear();

--- a/hikyuu_cpp/hikyuu/trade_sys/system/System.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/system/System.cpp
@@ -917,8 +917,10 @@ void System::_submitBuyShortRequest(const KRecord& today, const KRecord& src_tod
 
 TradeRecord System::_sellShort(const KRecord& today, const KRecord& src_today, Part from) {
     TradeRecord result;
-    if (getParam<bool>("support_borrow_stock") == false)
+    if (getParam<bool>("support_borrow_stock") == false) {
+        HKU_WARN("set system param support_borrow_stock to true to short sell");
         return result;
+    }
 
     if (getParam<bool>("sell_delay")) {
         _submitSellShortRequest(today, src_today, from);
@@ -949,7 +951,7 @@ TradeRecord System::_sellShortNow(const KRecord& today, const KRecord& src_today
 
     price_t goalPrice = _getShortGoalPrice(today.datetime, planPrice);
     price_t realPrice = _getRealSellPrice(today.datetime, planPrice);
-    TradeRecord record = m_tm->sell(today.datetime, m_stock, realPrice, number, stoploss, goalPrice,
+    TradeRecord record = m_tm->sellShort(today.datetime, m_stock, realPrice, number, stoploss, goalPrice,
                                     planPrice, PART_SIGNAL);
     if (BUSINESS_SELL_SHORT != record.business) {
         m_sellShortRequest.clear();

--- a/hikyuu_cpp/hikyuu/utilities/IniParser.cpp
+++ b/hikyuu_cpp/hikyuu/utilities/IniParser.cpp
@@ -8,9 +8,12 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <boost/nowide/fstream.hpp>
 
 #include "arithmetic.h"
 #include "IniParser.h"
+
+namespace nw = boost::nowide;
 
 namespace hku {
 
@@ -56,7 +59,7 @@ IniParser::~IniParser() {}
  * @param filename 指定文件名
  */
 void IniParser::read(const std::string& filename) {
-    std::ifstream inifile(filename.c_str(), std::ifstream::in);
+    nw::ifstream inifile(filename.c_str(), nw::ifstream::in);
     if (!inifile) {
         throw(std::invalid_argument("Can't read file(" + filename + ")!"));
     }

--- a/hikyuu_cpp/hikyuu/utilities/IniParser.cpp
+++ b/hikyuu_cpp/hikyuu/utilities/IniParser.cpp
@@ -8,12 +8,16 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#ifdef _MSC_VER
 #include <boost/nowide/fstream.hpp>
+#endif
 
 #include "arithmetic.h"
 #include "IniParser.h"
 
+#ifdef _MSC_VER
 namespace nw = boost::nowide;
+#endif
 
 namespace hku {
 
@@ -59,7 +63,11 @@ IniParser::~IniParser() {}
  * @param filename 指定文件名
  */
 void IniParser::read(const std::string& filename) {
+#ifdef _MSC_VER
     nw::ifstream inifile(filename.c_str(), nw::ifstream::in);
+#else
+    std::ifstream inifile(filename.c_str(), std::ifstream::in);
+#endif
     if (!inifile) {
         throw(std::invalid_argument("Can't read file(" + filename + ")!"));
     }

--- a/hikyuu_cpp/hikyuu/utilities/IniParser.cpp
+++ b/hikyuu_cpp/hikyuu/utilities/IniParser.cpp
@@ -8,16 +8,12 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
-#ifdef _MSC_VER
 #include <boost/nowide/fstream.hpp>
-#endif
 
 #include "arithmetic.h"
 #include "IniParser.h"
 
-#ifdef _MSC_VER
 namespace nw = boost::nowide;
-#endif
 
 namespace hku {
 
@@ -63,11 +59,7 @@ IniParser::~IniParser() {}
  * @param filename 指定文件名
  */
 void IniParser::read(const std::string& filename) {
-#ifdef _MSC_VER
     nw::ifstream inifile(filename.c_str(), nw::ifstream::in);
-#else
-    std::ifstream inifile(filename.c_str(), std::ifstream::in);
-#endif
     if (!inifile) {
         throw(std::invalid_argument("Can't read file(" + filename + ")!"));
     }

--- a/hikyuu_cpp/unit_test/hikyuu/test_main.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/test_main.cpp
@@ -56,12 +56,6 @@ void init_hikyuu_test() {
 }
 
 int main(int argc, char** argv) {
-#if defined(_WIN32)
-    // Windows 下设置控制台程序输出代码页为 UTF8
-    auto old_cp = GetConsoleOutputCP();
-    SetConsoleOutputCP(CP_UTF8);
-#endif
-
     doctest::Context context;
 
     // !!! THIS IS JUST AN EXAMPLE SHOWING HOW DEFAULTS/OVERRIDES ARE SET !!!
@@ -78,6 +72,11 @@ int main(int argc, char** argv) {
     context.setOption("no-breaks", true);  // don't break in the debugger when assertions fail
 
     init_hikyuu_test();
+#if defined(_WIN32)
+    // Windows 下设置控制台程序输出代码页为 UTF8
+    auto old_cp = GetConsoleOutputCP();
+    SetConsoleOutputCP(CP_UTF8);
+#endif
 
     int res = 0;
     {

--- a/hikyuu_cpp/unit_test/hikyuu/test_main.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/test_main.cpp
@@ -71,12 +71,12 @@ int main(int argc, char** argv) {
     // overrides
     context.setOption("no-breaks", true);  // don't break in the debugger when assertions fail
 
-    init_hikyuu_test();
 #if defined(_WIN32)
     // Windows 下设置控制台程序输出代码页为 UTF8
     auto old_cp = GetConsoleOutputCP();
     SetConsoleOutputCP(CP_UTF8);
 #endif
+    init_hikyuu_test();
 
     int res = 0;
     {

--- a/hikyuu_cpp/unit_test/hikyuu/test_main.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/test_main.cpp
@@ -56,6 +56,12 @@ void init_hikyuu_test() {
 }
 
 int main(int argc, char** argv) {
+#if defined(_WIN32)
+    // Windows 下设置控制台程序输出代码页为 UTF8
+    auto old_cp = GetConsoleOutputCP();
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     doctest::Context context;
 
     // !!! THIS IS JUST AN EXAMPLE SHOWING HOW DEFAULTS/OVERRIDES ARE SET !!!
@@ -71,11 +77,6 @@ int main(int argc, char** argv) {
     // overrides
     context.setOption("no-breaks", true);  // don't break in the debugger when assertions fail
 
-#if defined(_WIN32)
-    // Windows 下设置控制台程序输出代码页为 UTF8
-    auto old_cp = GetConsoleOutputCP();
-    SetConsoleOutputCP(CP_UTF8);
-#endif
     init_hikyuu_test();
 
     int res = 0;

--- a/hikyuu_extern_libs/packages/m/myboost/xmake.lua
+++ b/hikyuu_extern_libs/packages/m/myboost/xmake.lua
@@ -1,5 +1,36 @@
 package("myboost")
     set_base("boost")
+    local libnames = {"fiber",
+                      "coroutine",
+                      "context",
+                      "regex",
+                      "system",
+                      "container",
+                      "exception",
+                      "timer",
+                      "atomic",
+                      "graph",
+                      "serialization",
+                      "random",
+                      "wave",
+                      "date_time",
+                      "locale",
+                      "iostreams",
+                      "program_options",
+                      "test",
+                      "chrono",
+                      "contract",
+                      "graph_parallel",
+                      "json",
+                      "log",
+                      "thread",
+                      "filesystem",
+                      "math",
+                      "mpi",
+                      "nowide",
+                      "python",
+                      "stacktrace",
+                      "type_erasure"}
 
     on_load(function (package)
         function get_linkname(package, libname)

--- a/hikyuu_pywrap/indicator/_build_in.cpp
+++ b/hikyuu_pywrap/indicator/_build_in.cpp
@@ -426,6 +426,9 @@ Indicator (*SLICE_1)(const PriceList&, int64_t, int64_t) = SLICE;
 Indicator (*SLICE_2)(int64_t, int64_t, int) = SLICE;
 Indicator (*SLICE_3)(const Indicator&, int64_t, int64_t, int) = SLICE;
 
+Indicator (*RSI_1)(int) = RSI;
+Indicator (*RSI_2)(const Indicator&, int) = RSI;
+
 void export_Indicator_build_in() {
     def("KDATA", KDATA1);
     def("KDATA", KDATA3, R"(KDATA([data])
@@ -1480,7 +1483,8 @@ void export_Indicator_build_in() {
     :param int end: 终止位置（不包含本身）
     :param int result_index: 原输入数据中的结果集)");
 
-    def("RSI", RSI, (arg("n") = 14), R"(RSI([data, n=14])
+    def("RSI", RSI_1, (arg("n") = 14));
+    def("RSI", RSI_2, (arg("data"), arg("n") = 14), R"(RSI([data, n=14])
 
     相对强弱指数
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -160,6 +160,7 @@ add_requires("myboost " .. boost_version, {
     serialization = true,
     system = false,
     python = true,
+    nowide = is_plat("windows") and true or false,
     pyver = get_config("pyver"),
   },
 })

--- a/xmake.lua
+++ b/xmake.lua
@@ -155,12 +155,12 @@ add_requires("myboost " .. boost_version, {
   debug = is_mode("debug"),
   configs = {
     shared = is_plat("windows") and true or false,
-    data_time = true,
+    date_time = true,
     filesystem = true,
     serialization = true,
     system = false,
     python = true,
-    nowide = is_plat("windows") and true or false,
+    nowide = true,
     pyver = get_config("pyver"),
   },
 })


### PR DESCRIPTION
- fix debug.h typo
- update for commit bd5b610
- update TradeManager broker calls. I initialized `m_broker_last_datetime ` to epoch time so brokers get triggered automatically. Correct me if there is any problem
- update SignalBase and System to support short selling signals. Unit tests are added
- ~~`SetConsoleOutputCP` is moved. I got encoding print issue in `init_hikyuu_test` if code page is changed before that.~~
- use `boost::nowide` to handle config ini files. The standard library `<fstream>` of MSVC does NOT support unicode (UTF8) config. Replace `fstream` classes in `IniParser.cp` with `boost::nowide` variants. The library simply points to the standard library classes on Linux, but fix the UTF8 API on Windows. So I choose to remove the original line instead of special handling for Windows only
filepath. `std::wstring`  (UTF16) pathes will do but that requires a lot of refactoring. I got error reading my config because my laptop home directory has Chinese in it. 
- fix typo in xmake.lua
- fix `myboost`: `libnames` is not inherited so copy from official repo. Previously, all modules are built . After fixing it, the installation and building time go down significantly