### PR TITLE
fix linux build

### DIFF
--- a/hikyuu_cpp/hikyuu/xmake.lua
+++ b/hikyuu_cpp/hikyuu/xmake.lua
@@ -51,6 +51,7 @@ target("hikyuu")
     end
 
     if is_plat("linux", "cross") then
+        add_cxflags("-fPIC")
         if get_config("hdf5") then
             add_packages("hdf5")
         end


### PR DESCRIPTION
在linux环境下编译core失败
分支：master
平台：WSL2
配置：xmake f -m debug
报错：
[ 99%]: linking.debug core.so
error: /usr/bin/ld: build/debug/linux/x86_64/lib/libhikyuu.a(StrategyBase.cpp.o): relocation R_X86_64_TPOFF32 against `__tls_guard' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status