### PR TITLE
实现通达信时间函数

### DIFF
--- a/docs/source/indicator/indicator.rst
+++ b/docs/source/indicator/indicator.rst
@@ -263,6 +263,22 @@
     :rtype: Indicator
     
 
+.. py:function:: DATE([data])
+
+    取得该周期从1900以来的年月日。用法: DATE 例如函数返回1000101，表示2000年1月1日。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator
+
+
+.. py:function:: DAY([data])
+
+    取得该周期的日期。用法: DAY 函数返回有效值范围为(1-31)。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator
+
+
 .. py:function:: DECLINE([query=Query(-100), market='SH', stk_type='constant.STOCKTYPE_A'])
 
     下跌家数。当存在指定上下文且 ignore_context 为 false 时，将忽略 query, market, stk_type 参数。
@@ -416,6 +432,14 @@
     :rtype: Indicator
     
     
+.. py:function:: HOUR([data])
+
+    取得该周期的小时数。用法：HOUR 函数返回有效值范围为(0-23)，对于日线及更长的分析周期值为0。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator
+
+
 .. py:function:: HSL(kdata)
 
     获取换手率，等于 VOL(k) / CAPITAL(k)
@@ -597,6 +621,14 @@
     :rtype: Indicator
     
 
+.. py:function:: MINUTE([data])
+
+    取得该周期的分钟数。用法：MINUTE 函数返回有效值范围为(0-59)，对于日线及更长的分析周期值为0。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator
+
+
 .. py:function:: MOD(ind1, ind2)
 
     取整后求模。该函数仅为兼容通达信。实际上，指标求模可直接使用 % 操作符
@@ -607,6 +639,14 @@
 
     :param Indicator ind1:
     :param Indicator ind2:
+    :rtype: Indicator
+
+
+.. py:function:: MONTH([data])
+
+    取得该周期的月份。用法: MONTH 函数返回有效值范围为(1-12)。
+
+    :param data: 输入数据 KData
     :rtype: Indicator
 
 
@@ -872,6 +912,14 @@
     :rtype: Indicator
 
 
+.. py:function:: TIME([data])
+
+    取得该周期的时分秒。用法: TIME 函数返回有效值范围为(000000-235959)。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator
+
+
 .. py:function:: TIMELINE([k])
 
     分时价格数据
@@ -942,3 +990,18 @@
     :param Indicator ind2: 指标2
     :rtype: Indicator
 
+
+.. py:function:: WEEK([data])
+
+    取得该周期的星期数。用法：WEEK 函数返回有效值范围为(0-6)，0表示星期天。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator
+
+
+.. py:function:: YEAR([data])
+
+    取得该周期的年份。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator

--- a/hikyuu_cpp/hikyuu/indicator/build_in.h
+++ b/hikyuu_cpp/hikyuu/indicator/build_in.h
@@ -86,6 +86,7 @@
 #include "crt/SUM.h"
 #include "crt/SUMBARS.h"
 #include "crt/TAN.h"
+#include "crt/TIME.h"
 #include "crt/TIMELINE.h"
 #include "crt/TIMELINEVOL.h"
 #include "crt/UPNDAY.h"

--- a/hikyuu_cpp/hikyuu/indicator/crt/TIME.h
+++ b/hikyuu_cpp/hikyuu/indicator/crt/TIME.h
@@ -1,0 +1,69 @@
+/*
+ * IKDATA.h
+ *
+ *  Created on: 2013-2-14
+ *      Author: fasiondog
+ */
+
+#pragma once
+#include "../Indicator.h"
+
+namespace hku {
+
+/**
+ * 取得该周期从1900以来的年月日。用法: DATE 例如函数返回1000101，表示2000年1月1日。
+ * @ingroup Indicator
+ */
+Indicator HKU_API DATE();
+Indicator HKU_API DATE(const KData&);
+
+/**
+ * 取得该周期的时分秒。用法: TIME 函数返回有效值范围为(000000-235959)。
+ * @ingroup Indicator
+ */
+Indicator HKU_API TIME();
+Indicator HKU_API TIME(const KData&);
+
+/**
+ * 取得该周期的年份。
+ * @ingroup Indicator
+ */
+Indicator HKU_API YEAR();
+Indicator HKU_API YEAR(const KData&);
+
+/**
+ * 取得该周期的月份。用法: MONTH 函数返回有效值范围为(1-12)。
+ * @ingroup Indicator
+ */
+Indicator HKU_API MONTH();
+Indicator HKU_API MONTH(const KData&);
+
+/**
+ * 取得该周期的星期数。用法：WEEK 函数返回有效值范围为(0-6)，0表示星期天。
+ * @ingroup Indicator
+ */
+Indicator HKU_API WEEK();
+Indicator HKU_API WEEK(const KData&);
+
+/**
+ * 取得该周期的日期。用法: DAY 函数返回有效值范围为(1-31)。
+ * @ingroup Indicator
+ */
+Indicator HKU_API DAY();
+Indicator HKU_API DAY(const KData&);
+
+/**
+ * 取得该周期的小时数。用法：HOUR 函数返回有效值范围为(0-23)，对于日线及更长的分析周期值为0。
+ * @ingroup Indicator
+ */
+Indicator HKU_API HOUR();
+Indicator HKU_API HOUR(const KData&);
+
+/**
+ * 取得该周期的分钟数。用法：MINUTE 函数返回有效值范围为(0-59)，对于日线及更长的分析周期值为0。
+ * @ingroup Indicator
+ */
+Indicator HKU_API MINUTE();
+Indicator HKU_API MINUTE(const KData&);
+
+}  // namespace hku

--- a/hikyuu_cpp/hikyuu/indicator/imp/ITime.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ITime.cpp
@@ -13,15 +13,16 @@ BOOST_CLASS_EXPORT(hku::ITime)
 
 namespace hku {
 
-ITime::ITime() : IndicatorImp("TIME", 1) {
+ITime::ITime() : IndicatorImp("TIME") {
     setParam<string>("type", "time");
 }
 
 ITime::~ITime() {}
 
-ITime::ITime(const KData& k, const string& type) : IndicatorImp("TIME", 1) {
+ITime::ITime(const KData& k, const string& type) : IndicatorImp() {
     string type_name(type);
     to_upper(type_name);
+    m_name = type_name;
     setParam<string>("type", type_name);
     setParam<KData>("kdata", k);
     ITime::_calculate(Indicator());
@@ -45,57 +46,138 @@ void ITime::_calculate(const Indicator& data) {
 
     _readyBuffer(total, 1);
 
-    string type_name = getParam<string>("kpart");
+    string type_name = getParam<string>("type");
     if ("TIME" == type_name) {
-        m_name = "TIME";
         for (size_t i = 0; i < total; i++) {
             const auto& d = ds[i];
             _set(d.hour() * 10000 + d.minute() * 100 + d.second(), i);
         }
 
     } else if ("DATE" == type_name) {
-        m_name = "DATE";
         for (size_t i = 0; i < total; i++) {
             const auto& d = ds[i];
             _set((d.year() - 1900) * 10000 + d.month() * 100 + d.day(), i);
         }
 
     } else if ("YEAR" == type_name) {
-        m_name = "YEAR";
         for (size_t i = 0; i < total; i++) {
             _set(ds[i].year(), i);
         }
 
     } else if ("MONTH" == type_name) {
-        m_name = "MONTH";
         for (size_t i = 0; i < total; i++) {
             _set(ds[i].month(), i);
         }
 
     } else if ("WEEK" == type_name) {
-        m_name = "WEEK";
         for (size_t i = 0; i < total; i++) {
             _set(ds[i].dayOfWeek(), i);
         }
 
     } else if ("DAY" == type_name) {
-        m_name = "DAY";
         for (size_t i = 0; i < total; i++) {
             _set(ds[i].day(), i);
         }
 
     } else if ("HOUR" == type_name) {
-        m_name = "HOUR";
         for (size_t i = 0; i < total; i++) {
             _set(ds[i].hour(), i);
         }
 
     } else if ("MINUTE" == type_name) {
-        m_name = "MINUTE";
         for (size_t i = 0; i < total; i++) {
             _set(ds[i].minute(), i);
         }
     }
+}
+
+Indicator HKU_API DATE(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "DATE"));
+}
+
+Indicator HKU_API TIME(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "TIME"));
+}
+
+Indicator HKU_API YEAR(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "YEAR"));
+}
+
+Indicator HKU_API MONTH(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "MONTH"));
+}
+
+Indicator HKU_API WEEK(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "WEEK"));
+}
+
+Indicator HKU_API DAY(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "DAY"));
+}
+
+Indicator HKU_API HOUR(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "HOUR"));
+}
+
+Indicator HKU_API MINUTE(const KData& kdata) {
+    return Indicator(make_shared<ITime>(kdata, "MINUTE"));
+}
+
+//-----------------------------------------------------------
+Indicator HKU_API DATE() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "DATE");
+    p->name("DATE");
+    return p->calculate();
+}
+
+Indicator HKU_API TIME() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "TIME");
+    p->name("TIME");
+    return p->calculate();
+}
+
+Indicator HKU_API YEAR() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "YEAR");
+    p->name("YEAR");
+    return p->calculate();
+}
+
+Indicator HKU_API MONTH() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "MONTH");
+    p->name("MONTH");
+    return p->calculate();
+}
+
+Indicator HKU_API WEEK() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "WEEK");
+    p->name("WEEK");
+    return p->calculate();
+}
+
+Indicator HKU_API DAY() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "DAY");
+    p->name("DAY");
+    return p->calculate();
+}
+
+Indicator HKU_API HOUR() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "HOUR");
+    p->name("HOUR");
+    return p->calculate();
+}
+
+Indicator HKU_API MINUTE() {
+    IndicatorImpPtr p = make_shared<ITime>();
+    p->setParam<string>("type", "MINUTE");
+    p->name("MINUTE");
+    return p->calculate();
 }
 
 }  // namespace hku

--- a/hikyuu_cpp/hikyuu/indicator/imp/ITime.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ITime.cpp
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2023 hikyuu.org
+ *
+ *  Created on: 2023-11-09
+ *      Author: fasiondog
+ */
+
+#include "ITime.h"
+
+#if HKU_SUPPORT_SERIALIZATION
+BOOST_CLASS_EXPORT(hku::ITime)
+#endif
+
+namespace hku {
+
+ITime::ITime() : IndicatorImp("TIME", 1) {
+    setParam<string>("type", "time");
+}
+
+ITime::~ITime() {}
+
+ITime::ITime(const KData& k, const string& type) : IndicatorImp("TIME", 1) {
+    string type_name(type);
+    to_upper(type_name);
+    setParam<string>("type", type_name);
+    setParam<KData>("kdata", k);
+    ITime::_calculate(Indicator());
+}
+
+bool ITime::check() {
+    string part = getParam<string>("type");
+    return "TIME" == part || "DATE" == part || "YEAR" == part || "MONTH" == part ||
+           "WEEK" == part || "DAY" == part || "HOUR" == part || "MINUTE" == part;
+}
+
+void ITime::_calculate(const Indicator& data) {
+    HKU_WARN_IF(!isLeaf() && !data.empty(),
+                "The input is ignored because {} depends on the context!", m_name);
+
+    KData kdata = getContext();
+    size_t total = kdata.size();
+    HKU_IF_RETURN(total == 0, void());
+
+    DatetimeList ds = kdata.getDatetimeList();
+
+    _readyBuffer(total, 1);
+
+    string type_name = getParam<string>("kpart");
+    if ("TIME" == type_name) {
+        m_name = "TIME";
+        for (size_t i = 0; i < total; i++) {
+            const auto& d = ds[i];
+            _set(d.hour() * 10000 + d.minute() * 100 + d.second(), i);
+        }
+
+    } else if ("DATE" == type_name) {
+        m_name = "DATE";
+        for (size_t i = 0; i < total; i++) {
+            const auto& d = ds[i];
+            _set((d.year() - 1900) * 10000 + d.month() * 100 + d.day(), i);
+        }
+
+    } else if ("YEAR" == type_name) {
+        m_name = "YEAR";
+        for (size_t i = 0; i < total; i++) {
+            _set(ds[i].year(), i);
+        }
+
+    } else if ("MONTH" == type_name) {
+        m_name = "MONTH";
+        for (size_t i = 0; i < total; i++) {
+            _set(ds[i].month(), i);
+        }
+
+    } else if ("WEEK" == type_name) {
+        m_name = "WEEK";
+        for (size_t i = 0; i < total; i++) {
+            _set(ds[i].dayOfWeek(), i);
+        }
+
+    } else if ("DAY" == type_name) {
+        m_name = "DAY";
+        for (size_t i = 0; i < total; i++) {
+            _set(ds[i].day(), i);
+        }
+
+    } else if ("HOUR" == type_name) {
+        m_name = "HOUR";
+        for (size_t i = 0; i < total; i++) {
+            _set(ds[i].hour(), i);
+        }
+
+    } else if ("MINUTE" == type_name) {
+        m_name = "MINUTE";
+        for (size_t i = 0; i < total; i++) {
+            _set(ds[i].minute(), i);
+        }
+    }
+}
+
+}  // namespace hku

--- a/hikyuu_cpp/hikyuu/indicator/imp/ITime.h
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ITime.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 hikyuu.org
+ *
+ *  Created on: 2023-11-09
+ *      Author: fasiondog
+ */
+
+#pragma once
+#ifndef INDICATOR_IMP_ITIME_H_
+#define INDICATOR_IMP_ITIME_H_
+
+#include "../Indicator.h"
+
+namespace hku {
+
+/*
+ * 通达信时间函数实现
+ */
+class ITime : public IndicatorImp {
+    INDICATOR_IMP(ITime)
+    INDICATOR_NEED_CONTEXT
+    INDICATOR_IMP_NO_PRIVATE_MEMBER_SERIALIZATION
+
+public:
+    ITime();
+    ITime(const KData&, const string& type);
+    virtual ~ITime();
+};
+
+}  // namespace hku
+
+#endif  // INDICATOR_IMP_ITIME_H_

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_TIME.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_TIME.cpp
@@ -1,0 +1,246 @@
+/*
+ * test_IKData.cpp
+ *
+ *  Created on: 2013-2-12
+ *      Author: fasiondog
+ */
+
+#include "doctest/doctest.h"
+#include <fstream>
+#include <hikyuu/StockManager.h>
+#include <hikyuu/indicator/crt/TIME.h>
+
+using namespace hku;
+
+/**
+ * @defgroup test_indicator_TIME test_indicator_TIME
+ * @ingroup test_hikyuu_indicator_suite
+ * @{
+ */
+
+/** @par 检测点 */
+TEST_CASE("test_TIME") {
+    StockManager& sm = StockManager::instance();
+    Stock stock = sm.getStock("sh000001");
+    KData kdata;
+
+    /** @arg 无输入参数 */
+    Indicator date = DATE(), time = TIME(), year = YEAR(), month = MONTH(), week = WEEK(),
+              day = DAY(), hour = HOUR(), minute = MINUTE();
+    CHECK_EQ(date.size(), 0);
+    CHECK_EQ(date.empty(), true);
+    CHECK_EQ(date.name(), "DATE");
+
+    CHECK_EQ(time.size(), 0);
+    CHECK_EQ(time.empty(), true);
+    CHECK_EQ(time.name(), "TIME");
+
+    CHECK_EQ(year.size(), 0);
+    CHECK_EQ(year.empty(), true);
+    CHECK_EQ(year.name(), "YEAR");
+
+    CHECK_EQ(month.size(), 0);
+    CHECK_EQ(month.empty(), true);
+    CHECK_EQ(month.name(), "MONTH");
+
+    CHECK_EQ(week.size(), 0);
+    CHECK_EQ(week.empty(), true);
+    CHECK_EQ(week.name(), "WEEK");
+
+    CHECK_EQ(day.size(), 0);
+    CHECK_EQ(day.empty(), true);
+    CHECK_EQ(day.name(), "DAY");
+
+    CHECK_EQ(hour.size(), 0);
+    CHECK_EQ(hour.empty(), true);
+    CHECK_EQ(hour.name(), "HOUR");
+
+    CHECK_EQ(minute.size(), 0);
+    CHECK_EQ(minute.empty(), true);
+    CHECK_EQ(minute.name(), "MINUTE");
+
+    /** @arg 对应的KData为空 */
+    CHECK_EQ(kdata.empty(), true);
+
+    date = DATE(kdata);
+    CHECK_EQ(date.size(), 0);
+    CHECK_EQ(date.empty(), true);
+    CHECK_EQ(date.name(), "DATE");
+
+    time = TIME(kdata);
+    CHECK_EQ(time.size(), 0);
+    CHECK_EQ(time.empty(), true);
+    CHECK_EQ(time.name(), "TIME");
+
+    year = YEAR(kdata);
+    CHECK_EQ(year.size(), 0);
+    CHECK_EQ(year.empty(), true);
+    CHECK_EQ(year.name(), "YEAR");
+
+    month = MONTH(kdata);
+    CHECK_EQ(month.size(), 0);
+    CHECK_EQ(month.empty(), true);
+    CHECK_EQ(month.name(), "MONTH");
+
+    week = WEEK(kdata);
+    CHECK_EQ(week.size(), 0);
+    CHECK_EQ(week.empty(), true);
+    CHECK_EQ(week.name(), "WEEK");
+
+    day = DAY(kdata);
+    CHECK_EQ(day.size(), 0);
+    CHECK_EQ(day.empty(), true);
+    CHECK_EQ(day.name(), "DAY");
+
+    hour = HOUR(kdata);
+    CHECK_EQ(hour.size(), 0);
+    CHECK_EQ(hour.empty(), true);
+    CHECK_EQ(hour.name(), "HOUR");
+
+    minute = MINUTE(kdata);
+    CHECK_EQ(minute.size(), 0);
+    CHECK_EQ(minute.empty(), true);
+    CHECK_EQ(minute.name(), "MINUTE");
+
+    /** @arg 非空的KData */
+    KQuery query(-10);
+    kdata = stock.getKData(query);
+    size_t total = kdata.size();
+
+    date = DATE(kdata);
+    CHECK_EQ(date.name(), "DATE");
+    CHECK_EQ(date.size(), kdata.size());
+
+    time = TIME(kdata);
+    CHECK_EQ(time.name(), "TIME");
+    CHECK_EQ(time.size(), kdata.size());
+
+    year = YEAR(kdata);
+    CHECK_EQ(year.name(), "YEAR");
+    CHECK_EQ(year.size(), kdata.size());
+
+    month = MONTH(kdata);
+    CHECK_EQ(month.name(), "MONTH");
+    CHECK_EQ(month.size(), kdata.size());
+
+    week = WEEK(kdata);
+    CHECK_EQ(week.name(), "WEEK");
+    CHECK_EQ(week.size(), kdata.size());
+
+    day = DAY(kdata);
+    CHECK_EQ(day.name(), "DAY");
+    CHECK_EQ(day.size(), kdata.size());
+
+    hour = HOUR(kdata);
+    CHECK_EQ(hour.name(), "HOUR");
+    CHECK_EQ(hour.size(), kdata.size());
+
+    minute = MINUTE(kdata);
+    CHECK_EQ(minute.name(), "MINUTE");
+    CHECK_EQ(minute.size(), kdata.size());
+
+    for (size_t i = 0; i < total; ++i) {
+        auto d = kdata[i].datetime;
+        CHECK_EQ(date[i], (d.year() - 1900) * 10000 + d.month() * 100 + d.day());
+        CHECK_EQ(time[i], d.hour() * 10000 + d.minute() * 100 + d.second());
+        CHECK_EQ(year[i], d.year());
+        CHECK_EQ(month[i], d.month());
+        CHECK_EQ(week[i], d.dayOfWeek());
+        CHECK_EQ(day[i], d.day());
+        CHECK_EQ(hour[i], d.hour());
+        CHECK_EQ(minute[i], d.minute());
+    }
+
+    /** @arg 非空的KData */
+    date = DATE();
+    time = TIME();
+    year = YEAR();
+    month = MONTH();
+    week = WEEK();
+    day = DAY();
+    hour = HOUR();
+    minute = MINUTE();
+
+    date.setContext(stock, query);
+    time.setContext(stock, query);
+    year.setContext(stock, query);
+    month.setContext(stock, query);
+    week.setContext(stock, query);
+    day.setContext(stock, query);
+    hour.setContext(stock, query);
+    minute.setContext(stock, query);
+
+    CHECK_EQ(date.name(), "DATE");
+    CHECK_EQ(date.size(), kdata.size());
+
+    CHECK_EQ(time.name(), "TIME");
+    CHECK_EQ(time.size(), kdata.size());
+
+    CHECK_EQ(year.name(), "YEAR");
+    CHECK_EQ(year.size(), kdata.size());
+
+    CHECK_EQ(month.name(), "MONTH");
+    CHECK_EQ(month.size(), kdata.size());
+
+    CHECK_EQ(week.name(), "WEEK");
+    CHECK_EQ(week.size(), kdata.size());
+
+    CHECK_EQ(day.name(), "DAY");
+    CHECK_EQ(day.size(), kdata.size());
+
+    CHECK_EQ(hour.name(), "HOUR");
+    CHECK_EQ(hour.size(), kdata.size());
+
+    CHECK_EQ(minute.name(), "MINUTE");
+    CHECK_EQ(minute.size(), kdata.size());
+
+    for (size_t i = 0; i < total; ++i) {
+        auto d = kdata[i].datetime;
+        CHECK_EQ(date[i], (d.year() - 1900) * 10000 + d.month() * 100 + d.day());
+        CHECK_EQ(time[i], d.hour() * 10000 + d.minute() * 100 + d.second());
+        CHECK_EQ(year[i], d.year());
+        CHECK_EQ(month[i], d.month());
+        CHECK_EQ(week[i], d.dayOfWeek());
+        CHECK_EQ(day[i], d.day());
+        CHECK_EQ(hour[i], d.hour());
+        CHECK_EQ(minute[i], d.minute());
+    }
+}
+
+//-----------------------------------------------------------------------------
+// test export
+//-----------------------------------------------------------------------------
+#if HKU_SUPPORT_SERIALIZATION
+
+/** @par 检测点 */
+TEST_CASE("test_TIME_export") {
+    StockManager& sm = StockManager::instance();
+    string filename(sm.tmpdir());
+    filename += "/TIME.xml";
+
+    Stock stock = sm.getStock("sh000001");
+    KData kdata = stock.getKData(KQuery(-20));
+    Indicator ma1 = DATE(kdata);
+    {
+        std::ofstream ofs(filename);
+        boost::archive::xml_oarchive oa(ofs);
+        oa << BOOST_SERIALIZATION_NVP(ma1);
+    }
+
+    Indicator ma2;
+    {
+        std::ifstream ifs(filename);
+        boost::archive::xml_iarchive ia(ifs);
+        ia >> BOOST_SERIALIZATION_NVP(ma2);
+    }
+
+    CHECK_EQ(ma1.size(), ma2.size());
+    CHECK_EQ(ma1.discard(), ma2.discard());
+    CHECK_EQ(ma1.getResultNumber(), ma2.getResultNumber());
+    for (size_t i = 0; i < ma1.size(); ++i) {
+        CHECK_EQ(ma1.get(i, 0), doctest::Approx(ma2.get(i, 0)));
+    }
+}
+#endif /* #if HKU_SUPPORT_SERIALIZATION */
+
+/** @} */

--- a/hikyuu_pywrap/indicator/_build_in.cpp
+++ b/hikyuu_pywrap/indicator/_build_in.cpp
@@ -39,6 +39,30 @@ Indicator (*VOL3)() = VOL;
 Indicator (*KDATA_PART1)(const KData& kdata, const string& part) = KDATA_PART;
 Indicator (*KDATA_PART3)(const string& part) = KDATA_PART;
 
+Indicator (*DATE1)() = DATE;
+Indicator (*DATE2)(const KData&) = DATE;
+
+Indicator (*TIME1)() = TIME;
+Indicator (*TIME2)(const KData&) = TIME;
+
+Indicator (*YEAR1)() = YEAR;
+Indicator (*YEAR2)(const KData&) = YEAR;
+
+Indicator (*MONTH1)() = MONTH;
+Indicator (*MONTH2)(const KData&) = MONTH;
+
+Indicator (*WEEK1)() = WEEK;
+Indicator (*WEEK2)(const KData&) = WEEK;
+
+Indicator (*DAY1)() = DAY;
+Indicator (*DAY2)(const KData&) = DAY;
+
+Indicator (*HOUR1)() = HOUR;
+Indicator (*HOUR2)(const KData&) = HOUR;
+
+Indicator (*MINUTE1)() = MINUTE;
+Indicator (*MINUTE2)(const KData&) = MINUTE;
+
 // 太多选项选择的话，python中无法加载
 Indicator (*AMA_1)(int, int, int) = AMA;
 Indicator (*AMA_2)(const IndParam&, const IndParam&, const IndParam&) = AMA;
@@ -493,6 +517,70 @@ void export_Indicator_build_in() {
 
     :param data: 输入数据（KData 或 Indicator） 
     :param string kpart: KDATA|OPEN|HIGH|LOW|CLOSE|AMO|VOL
+    :rtype: Indicator)");
+
+    def("DATE", DATE1);
+    def("DATE", DATE2, R"(DATE([data])
+
+    取得该周期从1900以来的年月日。用法: DATE 例如函数返回1000101，表示2000年1月1日。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("TIME", TIME1);
+    def("TIME", TIME2, R"(TIME([data])
+
+    取得该周期的时分秒。用法: TIME 函数返回有效值范围为(000000-235959)。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("YEAR", YEAR1);
+    def("YEAR", YEAR2, R"(YEAR([data])
+
+    取得该周期的年份。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("MONTH", MONTH1);
+    def("MONTH", MONTH2, R"(MONTH([data])
+
+    取得该周期的月份。用法: MONTH 函数返回有效值范围为(1-12)。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("WEEK", WEEK1);
+    def("WEEK", WEEK2, R"(WEEK([data])
+
+    取得该周期的星期数。用法：WEEK 函数返回有效值范围为(0-6)，0表示星期天。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("DAY", DAY1);
+    def("DAY", DAY2, R"(DAY([data])
+
+    取得该周期的日期。用法: DAY 函数返回有效值范围为(1-31)。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("HOUR", HOUR1);
+    def("HOUR", HOUR2, R"(HOUR([data])
+
+    取得该周期的小时数。用法：HOUR 函数返回有效值范围为(0-23)，对于日线及更长的分析周期值为0。
+
+    :param data: 输入数据 KData
+    :rtype: Indicator)");
+
+    def("MINUTE", MINUTE1);
+    def("MINUTE", MINUTE2, R"(MINUTE([data])
+
+    取得该周期的分钟数。用法：MINUTE 函数返回有效值范围为(0-59)，对于日线及更长的分析周期值为0。
+
+    :param data: 输入数据 KData
     :rtype: Indicator)");
 
     def("PRICELIST", PRICELIST2, (arg("data"), arg("discard") = 0));


### PR DESCRIPTION
DATE 日期
取得该周期从1900以来的年月日。
用法： DATE　例如函数返回1000101，表示2000年1月1日。

TIME 时间
取得该周期的时分秒。
用法： TIME　函数返回有效值范围为(000000-235959)。

YEAR 年份
取得该周期的年份。
用法：YEAR

MONTH 月份
取得该周期的月份。
用法：MONTH　函数返回有效值范围为(1-12)。

WEEK 星期
取得该周期的星期数。
用法： WEEK　函数返回有效值范围为(0-6)，0表示星期天。

DAY 日期
取得该周期的日期。
用法： DAY　函数返回有效值范围为(1-31)。

HOUR 小时
取得该周期的小时数。
用法： HOUR　函数返回有效值范围为(0-23)，对于日线及更长的分析周期值为0。

MINUTE 分钟
取得该周期的分钟数。
用法： MINUTE　函数返回有效值范围为(0-59)，对于日线及更长的分析周期值为0。