### PR TITLE
set_warnings("all", "error")会导致重复编译

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -100,12 +100,7 @@ set_configvar("HKU_ENABLE_MYSQL_KDATA", get_config("mysql") and 1 or 0)
 set_configvar("HKU_ENABLE_SQLITE_KDATA", get_config("sqlite") and 1 or 0)
 set_configvar("HKU_ENABLE_TDX_KDATA", get_config("tdx") and 1 or 0)
 
--- set warning all as error
-if is_plat("windows") then
-   set_warnings("all", "error")
-else
-    set_warnings("all")
-end
+set_warnings("all")
 
 -- set language: C99, c++ standard
 set_languages("cxx17", "c99")


### PR DESCRIPTION
环境： Win11
配置：debug和release都有
问题：`set_warnings("all", "error")`导致即使文件没有任何变化还是会重新编译很多cpp
复现：`xmake -b core`运行多次，不修改任何源文件，重复几次后就会重新编译