### PR TITLE
解决windows上面没有使用UTF-8编码导致错误

### DIFF
--- a/hikyuu/data/hku_config_template.py
+++ b/hikyuu/data/hku_config_template.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-hdf5_template = """
+hdf5_template = u"""
 [hikyuu]
 tmpdir = {dir}/tmp
 datadir = {dir}

--- a/hikyuu/gui/HikyuuTDX.py
+++ b/hikyuu/gui/HikyuuTDX.py
@@ -99,10 +99,7 @@ class MyMainWindow(QMainWindow, Ui_MainWindow):
             if not os.path.lexists(data_dir + '/tmp'):
                 os.mkdir(data_dir + '/tmp')
             # 此处不能使用 utf-8 参数，否则导致Windows下getBlock无法找到板块分类
-            # with open(filename, 'w', encoding='utf-8') as f:
-
-            with open(filename, 'w') as f:
-
+            with open(filename, 'w', encoding='utf-8') as f:
                 f.write(
                     hku_config_template.hdf5_template.format(
                         dir=data_dir,
@@ -135,7 +132,7 @@ class MyMainWindow(QMainWindow, Ui_MainWindow):
 
         else:
             data_dir = current_config['mysql']['tmpdir']
-            with open(filename, 'w') as f:
+            with open(filename, 'w', encoding="utf-8") as f:
                 f.write(
                     hku_config_template.mysql_template.format(
                         dir=data_dir,


### PR DESCRIPTION
UnicodeDecodeError: 'utf-8' codec can't decode byte
