### PR TITLE
ignore .clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .project
 .pyproject
 .vscode
+.clangd
 .vs
 .ipynb_checkpoints
 nohup.out


### PR DESCRIPTION
I have a .clangd file like this for my neovim LSP
```
# patch your C++ standard headers here to make clang happy
CompileFlags:
  CompilationDatabase: .vscode
  Add: [
    -isystem,
    /usr/include/c++/13.2.1,
    -isystem,
    /usr/include/c++/13.2.1/backward,
    -isystem,
    /usr/local/include,
    -isystem,
    /usr/include,
    -isystem,
    /usr/include/x86_64-linux-gnu/c++/13.2.1,
  ]
```

This file could have some user-specific settings to guide clangd where the standard C++ headers are, it may not be
a good idea to track it.