### PR TITLE
fix conda environment python include path

### DIFF
--- a/hikyuu_pywrap/xmake.lua
+++ b/hikyuu_pywrap/xmake.lua
@@ -51,7 +51,13 @@ target("core")
         end
     
         -- get python include directory.
-        local pydir = try { function () return os.iorun("python3-config --includes"):trim() end }
+        local pydir = nil;
+        if os.getenv("CONDA_PREFIX") ~= nil then
+          local py3config = os.getenv("CONDA_PREFIX") .. "/bin/python3-config"
+          pydir = try { function () return os.iorun(py3config .. " --includes"):trim() end }
+        else
+          pydir = try { function () return os.iorun("python3-config --includes"):trim() end }
+        end
         assert(pydir, "python3-config not found!")
         target:add("cxflags", pydir)   
     end)


### PR DESCRIPTION
Correctly handle conda env (base or other envs) when they are activated.
Expected outcome: conda activate something, run `xmake build core`, the result `core.so` should be able to
match that python interpreter version.

LIMITATION: This ONLY addresses the conda env situation. For example, if you have multiple vanilla pythons
on your computer, or you have venvs. The issue will remain until xmake changes their code.