### PR TITLE
其他市场扩展

### DIFF
--- a/hikyuu_cpp/hikyuu/Stock.cpp
+++ b/hikyuu_cpp/hikyuu/Stock.cpp
@@ -93,7 +93,10 @@ Stock::Data::Data(const string& market, const string& code, const string& name, 
     }
 
     to_upper(m_market);
-    m_market_code = m_market + m_code;
+    if (m_type == STOCKTYPE_CRYPTO)
+        m_market_code = m_market + "/" + m_code;
+    else
+        m_market_code = m_market + m_code;
 
     const auto& ktype_list = KQuery::getAllKType();
     for (const auto& ktype : ktype_list) {

--- a/hikyuu_cpp/hikyuu/Stock.cpp
+++ b/hikyuu_cpp/hikyuu/Stock.cpp
@@ -93,16 +93,19 @@ Stock::Data::Data(const string& market, const string& code, const string& name, 
     }
 
     to_upper(m_market);
-    if (m_type == STOCKTYPE_CRYPTO)
-        m_market_code = m_market + "/" + m_code;
-    else
-        m_market_code = m_market + m_code;
+    m_market_code = marketCode();
 
     const auto& ktype_list = KQuery::getAllKType();
     for (const auto& ktype : ktype_list) {
         pMutex[ktype] = new std::shared_mutex();
         pKData[ktype] = nullptr;
     }
+}
+
+string Stock::Data::marketCode() const {
+    if (m_type == STOCKTYPE_CRYPTO)
+        return  m_market + "/" + m_code;
+    return m_market + m_code;
 }
 
 Stock::Data::~Data() {

--- a/hikyuu_cpp/hikyuu/Stock.h
+++ b/hikyuu_cpp/hikyuu/Stock.h
@@ -259,7 +259,7 @@ struct HKU_API Stock::Data {
     Data(const string& market, const string& code, const string& name, uint32_t type, bool valid,
          const Datetime& startDate, const Datetime& lastDate, price_t tick, price_t tickValue,
          int precision, double minTradeNumber, double maxTradeNumber);
-
+    string marketCode() const;
     virtual ~Data();
 };
 

--- a/hikyuu_cpp/hikyuu/StockManager.cpp
+++ b/hikyuu_cpp/hikyuu/StockManager.cpp
@@ -469,19 +469,14 @@ void StockManager::loadAllStocks() {
         } catch (...) {
             endDate = Null<Datetime>();
         }
-        string market_code;
-        if (info.type == STOCKTYPE_CRYPTO)
-            market_code = format("{}/{}", info.market, info.code);
-        else
-            market_code = format("{}{}", info.market, info.code);
+        Stock _stock(info.market, info.code, info.name, info.type, info.valid, startDate,
+                    endDate, info.tick, info.tickValue, info.precision, info.minTradeNumber,
+                    info.maxTradeNumber);
+        string market_code = _stock.market_code();;
         to_upper(market_code);
         auto iter = m_stockDict.find(market_code);
         if (iter == m_stockDict.end()) {
-            Stock stock(info.market, info.code, info.name, info.type, info.valid, startDate,
-                        endDate, info.tick, info.tickValue, info.precision, info.minTradeNumber,
-                        info.maxTradeNumber);
-            m_stockDict[market_code] = stock;
-
+            m_stockDict[market_code] = _stock;
         } else {
             Stock& stock = iter->second;
             if (!stock.m_data) {

--- a/hikyuu_cpp/hikyuu/StockManager.cpp
+++ b/hikyuu_cpp/hikyuu/StockManager.cpp
@@ -469,8 +469,11 @@ void StockManager::loadAllStocks() {
         } catch (...) {
             endDate = Null<Datetime>();
         }
-
-        string market_code = format("{}{}", info.market, info.code);
+        string market_code;
+        if (info.type == STOCKTYPE_CRYPTO)
+            market_code = format("{}/{}", info.market, info.code);
+        else
+            market_code = format("{}{}", info.market, info.code);
         to_upper(market_code);
         auto iter = m_stockDict.find(market_code);
         if (iter == m_stockDict.end()) {

--- a/hikyuu_cpp/hikyuu/StockTypeInfo.h
+++ b/hikyuu_cpp/hikyuu/StockTypeInfo.h
@@ -23,6 +23,7 @@ namespace hku {
 #define STOCKTYPE_BOND 7   /// 债券
 #define STOCKTYPE_GEM 8    /// 创业板
 #define STOCKTYPE_START 9  /// 科创板
+#define STOCKTYPE_CRYPTO 10 /// 数字货币
 
 #define STOCKTYPE_TMP 999  /// 用于临时Stock
 

--- a/hikyuu_cpp/hikyuu/trade_sys/moneymanager/MoneyManagerBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/moneymanager/MoneyManagerBase.cpp
@@ -80,7 +80,9 @@ double MoneyManagerBase ::getSellNumber(const Datetime& datetime, const Stock& s
         HKU_IF_RETURN(!getParam<bool>("disable_cn_force_clean_position"), MAX_DOUBLE);
     }
 
-    HKU_IF_RETURN(risk <= 0.0, 0.0);
+    HKU_ERROR_IF_RETURN(risk <= 0.0, 0.0,
+      "risk is negative! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f}) Part({})", datetime,
+      stock.market_code(), price, risk, getSystemPartName(from));
     return _getSellNumber(datetime, stock, price, risk, from);
 }
 
@@ -93,7 +95,7 @@ double MoneyManagerBase ::getBuyNumber(const Datetime& datetime, const Stock& st
 
     HKU_ERROR_IF_RETURN(
       risk <= 0.0, 0.0,
-      "risk is zero! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f}) Part({})", datetime,
+      "risk is negative! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f}) Part({})", datetime,
       stock.market_code(), price, risk, getSystemPartName(from));
 
     HKU_TRACE_IF_RETURN(m_tm->getStockNumber() >= getParam<int>("max-stock"), 0.0,
@@ -145,8 +147,8 @@ double MoneyManagerBase ::getSellShortNumber(const Datetime& datetime, const Sto
     HKU_ERROR_IF_RETURN(!m_tm, 0.0,
                         "m_tm is null! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f})",
                         datetime, stock.market_code(), price, risk);
-    HKU_ERROR_IF_RETURN(risk <= 0.0, 0.0,
-                        "risk is zero! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f})",
+    HKU_ERROR_IF_RETURN(risk >= 0.0, 0.0,
+                        "risk is positive! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f})",
                         datetime, stock.market_code(), price, risk);
     return _getSellShortNumber(datetime, stock, price, risk, from);
 }
@@ -156,8 +158,8 @@ double MoneyManagerBase ::getBuyShortNumber(const Datetime& datetime, const Stoc
     HKU_ERROR_IF_RETURN(!m_tm, 0.0,
                         "m_tm is null! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f})",
                         datetime, stock.market_code(), price, risk);
-    HKU_ERROR_IF_RETURN(risk <= 0.0, 0.0,
-                        "m_tm is null! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f})",
+    HKU_ERROR_IF_RETURN(risk >= 0.0, 0.0,
+                        "risk is positive! Datetime({}) Stock({}) price({:<.3f}) risk({:<.2f})",
                         datetime, stock.market_code(), price, risk);
     return _getBuyShortNumber(datetime, stock, price, risk, from);
 }


### PR DESCRIPTION
1. 这个patch主要处理了类似crypto或者美股这样纯字母的的ticker，OKX/BTC-USD或者NYSE/AAPL这样，交易所和代码之间需要一个分隔符，否则NYSEAAPL看着很费力

2. 处理空头仓位的时候risk的报错，例子：
```python
#创建模拟交易账户进行回测，初始资金30万
my_tm = crtTM(init_cash = 300000)

#创建信号指示器（相对强弱信号）
ind = RSI(C, 24)
my_sg = SG_Band(ind, 30, 70)

my_sg.set_param("alternate", True)
my_sg.set_param("support_borrow_stock", True)

#固定每次买入1股
my_mm = MM_FixedCount(1)

#创建交易系统并运行
sys = SYS_Simple(tm = my_tm, sg = my_sg, mm = my_mm)
sys.set_param("buy_delay", False)
sys.set_param("sell_delay", False)
sys.set_param("support_borrow_stock", True)
#日线信号
candle_num = 500
q = Query(-candle_num, constant.null_int64, Query.DAY)
symbol = 'OKX/BTC-USDT'
sys.run(sm[symbol], q)
```