### PR TITLE
增加 sys.performance 绘制系统性能，增加sharp比率最大回撤等简化的绩效显示

### DIFF
--- a/hikyuu/draw/drawplot/__init__.py
+++ b/hikyuu/draw/drawplot/__init__.py
@@ -48,6 +48,7 @@ from .matplotlib_draw import ax_draw_macd as mpl_ax_draw_macd
 from .matplotlib_draw import ax_draw_macd2 as mpl_ax_draw_macd2
 from .matplotlib_draw import ax_set_locator_formatter as mpl_ax_set_locator_formatter
 from .matplotlib_draw import adjust_axes_show as mpl_adjust_axes_show
+from .matplotlib_draw import sys_performance as mpl_sys_performance
 
 from .bokeh_draw import gcf as bk_gcf
 from .bokeh_draw import gca as bk_gca
@@ -123,6 +124,7 @@ def use_draw_with_matplotlib():
     ConditionBase.plot = mpl_cnplot
 
     System.plot = mpl_sysplot
+    System.performance = mpl_sys_performance
 
 
 def use_draw_with_echarts():


### PR DESCRIPTION
（注：仅支持 matplotlib 绘图）

```python
my_tm = crtTM(init_cash = 300000)
my_sg = SG_Flex(EMA(CLOSE(), n=5), slow_n=10)
my_mm = MM_FixedPercent(1.0)
sys = SYS_Simple(tm = my_tm, sg = my_sg, mm = my_mm)
sys.run(sm['sz000001'], Query(-1550))
sys.performance()
```
![output](https://github.com/fasiondog/hikyuu/assets/1145161/fb1b6eee-784b-41e9-a375-313917dab62c)


