### PR TITLE
feat(core): 添加判断是否为 Python 对象的接口, 添加python对象clone并行保护

### DIFF
--- a/hikyuu_cpp/hikyuu/data_driver/KDataDriver.h
+++ b/hikyuu_cpp/hikyuu/data_driver/KDataDriver.h
@@ -119,6 +119,11 @@ public:
      */
     virtual TransList getTransList(const string& market, const string& code, const KQuery& query);
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     bool checkType();
 

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
@@ -209,6 +209,8 @@ protected:
     // 用于动态参数时，更新 discard
     void _update_discard();
 
+    virtual bool isPythonObject() const;
+
 protected:
     string m_name;
     size_t m_discard;
@@ -410,6 +412,10 @@ inline IndicatorImp::value_t const* IndicatorImp::data(size_t result_idx) const 
 
 inline size_t IndicatorImp::_get_step_start(size_t pos, size_t step, size_t discard) {
     return step == 0 || pos < discard + step ? discard : pos + 1 - step;
+}
+
+inline bool IndicatorImp::isPythonObject() const {
+    return false;
 }
 
 } /* namespace hku */

--- a/hikyuu_cpp/hikyuu/trade_manage/TradeCostBase.h
+++ b/hikyuu_cpp/hikyuu/trade_manage/TradeCostBase.h
@@ -106,6 +106,11 @@ public:
     /** 继承子类必须实现私有变量的克隆接口 */
     virtual TradeCostPtr _clone() = 0;
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     string m_name;
 

--- a/hikyuu_cpp/hikyuu/trade_manage/TradeManagerBase.h
+++ b/hikyuu_cpp/hikyuu/trade_manage/TradeManagerBase.h
@@ -766,6 +766,11 @@ public:
       const Datetime& datetime = Datetime::now());
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;            // 账户名称
     TradeCostPtr m_costfunc;  // 成本算法
 

--- a/hikyuu_cpp/hikyuu/trade_sys/allocatefunds/AllocateFundsBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/allocatefunds/AllocateFundsBase.h
@@ -101,6 +101,11 @@ public:
     static void adjustWeight(SystemWeightList& sw_list, double can_allocate_weight,
                              bool auto_adjust, bool ignore_zero);
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     void initParam();
 

--- a/hikyuu_cpp/hikyuu/trade_sys/condition/ConditionBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/condition/ConditionBase.h
@@ -110,6 +110,11 @@ public:
     }
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;
     KData m_kdata;
     TMPtr m_tm;

--- a/hikyuu_cpp/hikyuu/trade_sys/environment/EnvironmentBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/environment/EnvironmentBase.h
@@ -94,6 +94,11 @@ public:
     virtual EnvironmentPtr _clone() = 0;
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;
     KQuery m_query;
     map<Datetime, size_t> m_date_index;

--- a/hikyuu_cpp/hikyuu/trade_sys/moneymanager/MoneyManagerBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/moneymanager/MoneyManagerBase.h
@@ -153,6 +153,11 @@ public:
     virtual MoneyManagerPtr _clone() = 0;
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;
     KQuery m_query;
     TradeManagerPtr m_tm;

--- a/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.h
@@ -143,6 +143,11 @@ public:
     virtual MultiFactorPtr _clone() = 0;
     virtual IndicatorList _calculate(const vector<IndicatorList>&) = 0;
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     /** 执行计算 */
     void calculate();

--- a/hikyuu_cpp/hikyuu/trade_sys/portfolio/Portfolio.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/portfolio/Portfolio.h
@@ -115,6 +115,10 @@ private:
                                      const string& mode);
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
     // 跟踪打印当前TM持仓情况
     void traceMomentTMAfterRunAtOpen(const Datetime& date);
     void traceMomentTMAfterRunAtClose(const Datetime& date);

--- a/hikyuu_cpp/hikyuu/trade_sys/profitgoal/ProfitGoalBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/profitgoal/ProfitGoalBase.h
@@ -83,6 +83,11 @@ public:
     virtual void _calculate() = 0;
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;
     KData m_kdata;
     TradeManagerPtr m_tm;

--- a/hikyuu_cpp/hikyuu/trade_sys/selector/SelectorBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/selector/SelectorBase.h
@@ -134,6 +134,11 @@ public:
 
     virtual string str() const;
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     void initParam();
 

--- a/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.h
@@ -130,6 +130,11 @@ public:
     /** 子类计算接口，在setTO中调用 */
     virtual void _calculate(const KData&) = 0;
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     void initParam();
 

--- a/hikyuu_cpp/hikyuu/trade_sys/slippage/SlippageBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/slippage/SlippageBase.h
@@ -72,6 +72,11 @@ public:
     virtual void _calculate() = 0;
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;
     KData m_kdata;
 

--- a/hikyuu_cpp/hikyuu/trade_sys/stoploss/StoplossBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/stoploss/StoplossBase.h
@@ -87,6 +87,11 @@ public:
     virtual void _calculate() = 0;
 
 protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
+protected:
     string m_name;
     TradeManagerPtr m_tm;
     KData m_kdata;

--- a/hikyuu_cpp/hikyuu/trade_sys/system/System.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/system/System.h
@@ -265,6 +265,11 @@ public:
     // 处理延迟买入请求，仅供 PF 调用
     virtual TradeRecord pfProcessDelayBuyRequest(const Datetime& date);
 
+protected:
+    virtual bool isPythonObject() const {
+        return false;
+    }
+
 private:
     bool _environmentIsValid(const Datetime& datetime);
     bool _conditionIsValid(const Datetime& datetime);

--- a/hikyuu_pywrap/trade_sys/_Condition.cpp
+++ b/hikyuu_pywrap/trade_sys/_Condition.cpp
@@ -16,6 +16,7 @@ class PyConditionBase : public ConditionBase {
 
 public:
     using ConditionBase::ConditionBase;
+
     PyConditionBase(const ConditionBase& base) : ConditionBase(base) {}
 
     void _calculate() override {


### PR DESCRIPTION
在多个基类中添加了虚函数 isPythonObject()，用于判断对象是否为 Python 对象。这项改动主要用于优化 Python 绑定，提高代码的灵活性和效率。

- 在 KDataDriver、IndicatorImp、TradeCostBase 等多个基类中添加 isPythonObject() 方法
- 默认实现返回 false，Python 绑定的类会重写该方法返回 true
- 修改 PY_CLONE 宏，根据 isPythonObject() 的返回值决定是否使用 Python 克隆逻辑