### PR TITLE
perf(indicator): 优化参数获取性能

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -533,7 +533,7 @@ DatetimeList IndicatorImp::getDatetimeList() const {
 
 Datetime IndicatorImp::getDatetime(size_t pos) const {
     if (haveParam("align_date_list")) {
-        DatetimeList dates(getParam<DatetimeList>("align_date_list"));
+        const DatetimeList &dates = getParam<const DatetimeList &>("align_date_list");
         return pos < dates.size() ? dates[pos] : Null<Datetime>();
     }
     const KData &k = getContext();
@@ -547,7 +547,7 @@ IndicatorImp::value_t IndicatorImp::getByDate(Datetime date, size_t num) {
 
 size_t IndicatorImp::getPos(Datetime date) const {
     if (haveParam("align_date_list")) {
-        DatetimeList dates(getParam<DatetimeList>("align_date_list"));
+        const DatetimeList &dates(getParam<const DatetimeList &>("align_date_list"));
         auto iter = std::lower_bound(dates.begin(), dates.end(), date);
         if (iter != dates.end() && *iter == date) {
             return iter - dates.begin();

--- a/hikyuu_cpp/hikyuu/indicator/imp/IBlockSetNum.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IBlockSetNum.cpp
@@ -35,14 +35,14 @@ void IBlockSetNum::_checkParam(const string& name) const {
 }
 
 void IBlockSetNum::_calculate(const Indicator& ind) {
-    Block block = getParam<Block>("block");
+    const Block block = getParam<const Block&>("block");
     bool ignore_context = getParam<bool>("ignore_context");
     const KData& k = getContext();
     DatetimeList dates;
     if (!ignore_context && !k.empty()) {
         dates = k.getDatetimeList();
     } else {
-        KQuery q = getParam<KQuery>("query");
+        const KQuery& q = getParam<const KQuery&>("query");
         if (q != KQuery(0, 0)) {
             dates = StockManager::instance().getTradingCalendar(q, getParam<string>("market"));
         }

--- a/hikyuu_cpp/hikyuu/indicator/imp/IInSum.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IInSum.cpp
@@ -225,7 +225,7 @@ static void insum_rank_asc(const IndicatorList& inds, Indicator::value_t* dst, c
 }
 
 void IInSum::_calculate(const Indicator& ind) {
-    Block block = getParam<Block>("block");
+    const Block block = getParam<const Block&>("block");
     bool ignore_context = getParam<bool>("ignore_context");
     const KData& k = getContext();
     KQuery q;

--- a/hikyuu_cpp/hikyuu/indicator/imp/IPriceList.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IPriceList.cpp
@@ -43,7 +43,7 @@ void IPriceList::_calculate(const Indicator& data) {
 
     DatetimeList align_dates =
       haveParam("align_date_list") ? getParam<DatetimeList>("align_date_list") : DatetimeList();
-    PriceList x = getParam<PriceList>("data");
+    const PriceList& x = getParam<const PriceList&>("data");
     int x_discard = getParam<int>("discard");
     size_t x_total = x.size();
 

--- a/hikyuu_cpp/hikyuu/indicator/imp/ISlice.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ISlice.cpp
@@ -39,7 +39,7 @@ void ISlice::_calculate(const Indicator& data) {
     // 如果在叶子节点，直接取自身的data参数
     if (isLeaf()) {
         m_discard = 0;
-        PriceList x = getParam<PriceList>("data");
+        const PriceList& x = getParam<const PriceList&>("data");
         size_t total = x.size();
         int64_t startix = getParam<int64_t>("start");
         if (startix < 0) {

--- a/hikyuu_cpp/hikyuu/trade_sys/allocatefunds/imp/FixedWeightListAllocateFunds.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/allocatefunds/imp/FixedWeightListAllocateFunds.cpp
@@ -39,7 +39,7 @@ void FixedWeightListAllocateFunds::_checkParam(const string& name) const {
 SystemWeightList FixedWeightListAllocateFunds ::_allocateWeight(const Datetime& date,
                                                                 const SystemWeightList& se_list) {
     SystemWeightList result;
-    PriceList weights = getParam<PriceList>("weights");
+    const PriceList& weights = getParam<const PriceList&>("weights");
     size_t w_total = weights.size();
     size_t wi = 0;
     for (auto iter = se_list.begin(); iter != se_list.end() && wi < w_total; ++iter) {


### PR DESCRIPTION
- 将 IndicatorImp.cpp 中的 getDatetime 和 getPos 方法改为引用传递， 避免 DatetimeList 的重复拷贝
- 将 IBlockSetNum.cpp 中的 Block 和 KQuery 参数改为引用传递， 减少对象拷贝开销
- 将 IInSum.cpp 中的 Block 参数改为引用传递
- 将 IPriceList.cpp 中的 PriceList 参数改为引用传递
- 将 ISlice.cpp 中的 PriceList 参数改为引用传递
- 将 FixedWeightListAllocateFunds.cpp 中的 PriceList 参数改为引用传递

所有修改都采用 const 引用方式，保持原有功能不变的同时提升性能