### PR TITLE
fix(xmake): 移除boost配置中不被xmake-repo支持的mysql组件选项

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -173,8 +173,7 @@ local boost_config = {
             random = true,
             thread = true,
             asio = true,
-            openssl = has_config("mysql"),
-            mysql = has_config("mysql"),            
+            openssl = has_config("mysql"),            
             cmake = true,
     }}
 


### PR DESCRIPTION
xmake-repo 的 boost 包(libs.lua)不支持 mysql 配置项。传入 mysql = true 会导致 boost 包的配置 hash 与已安装包不匹配，xmake 找不到匹配的包后将
boost __enabled 设为 false，致使 boost include 路径未被加入编译命令， 从而引发 "fatal error C1083: 无法打开包括文件: boost/mysql.hpp"。

Bug 由 f18374b00 引入。Boost.MySQL 是 header-only 组件，只要 boost 的 include 路径正确即可正常使用，无需额外的 config 选项。