### PR TITLE
fix(xmake): 将 add_defines 改为 add_cxflags 确保 MSVC 预处理器定义正确传递

### DIFF
--- a/hikyuu_cpp/hikyuu/xmake.lua
+++ b/hikyuu_cpp/hikyuu/xmake.lua
@@ -81,8 +81,7 @@ target("hikyuu")
 
     if is_plat("windows") then
         if is_kind("shared") then
-            add_defines("HKU_API=__declspec(dllexport)")
-            add_defines("HKU_UTILS_API=__declspec(dllexport)")
+            add_cxflags("/DHKU_API=__declspec(dllexport)", "/DHKU_UTILS_API=__declspec(dllexport)")
         end
     end
 

--- a/hikyuu_pywrap/xmake.lua
+++ b/hikyuu_pywrap/xmake.lua
@@ -20,8 +20,7 @@ target("core")
     end
 
     if is_plat("windows") and get_config("kind") == "shared" then
-        add_defines("HKU_API=__declspec(dllimport)")
-        add_defines("HKU_UTILS_API=__declspec(dllimport)")
+        add_cxflags("/DHKU_API=__declspec(dllimport)", "/DHKU_UTILS_API=__declspec(dllimport)")
         add_cxflags("-wd4566")
     end
     


### PR DESCRIPTION
add_defines 在 MSVC 下可能无法正确传递 __declspec 宏定义，改用 add_cxflags 显式添加 /D 前缀，确保 HKU_API 和 HKU_UTILS_API 在 DLL 边界上正确展开。

原因：add_defines("KEY=__declspec(dllexport)") 中 __declspec(dllexport) 含括号，xmake 处理时把这个值丢掉了，导致编译命令里没有-DHKU_UTILS_API。用 add_cxflags 传原始 /D 标志绕过 xmake 的处理。