### PR TITLE
fix(multifactor): 修复风格因子中性化的数据竞争与数学错误

### DIFF
--- a/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp
@@ -669,33 +669,55 @@ vector<IndicatorList> MultiFactorBase::getAllSrcFactors() {
 
     all_stk_inds = m_factorset.getValues(m_stks, m_query, true, fill_null, true, true, m_ref_dates);
 
-    unordered_map<string, IndicatorList> use_style_inds;
+    // 风格因子按 [风格因子名][风格因子][股票] 三维存储（vector<IndicatorList>）。
+    //
+    // 原实现为 [风格因子名][风格因子] 二维，每条风格因子全市场共享同一条时序，
+    // 导致两个独立缺陷：
+    //   1) 并发提取时多线程写同一个 Indicator（对 shared_ptr 对象本身的非原子
+    //      赋值是 C++ UB），是启用风格中性化后 get_ic / get_all_src_factors
+    //      进程直接崩溃（segfault，无 Python 异常）的根因；
+    //   2) 截面回归的自变量对所有股票取同一值，退化为常数列，与截距共线，
+    //      市值/风格中性化在数学上彻底失效（残差≈原值）。
+    //
+    // 补上股票维度后：
+    //   - 写隔离：每个 si 线程只写 per_factor[j][si]，不同 si 写不同槽；
+    //   - 读隔离：每线程对模板 styles[j] 先 clone() 出独立副本再 ALIGN 计算，
+    //     calculate() 只写本线程副本的 buffer，不触碰共享的 styles[j]。
+    //     （IndicatorImp::clone() 对根源对象严格只读，经代码核实，故并发
+    //      styles[j].clone() 安全；此处 styles[j] 为用户传入的根 Indicator。）
+    unordered_map<string, vector<IndicatorList>> use_style_inds;
     for (const auto& [style_ind_name, style_inds] : m_special_style_inds) {
-        use_style_inds[style_ind_name] = IndicatorList(style_inds.size());
+        auto& per_factor = use_style_inds[style_ind_name];
+        per_factor.resize(style_inds.size());
+        for (auto& v : per_factor) {
+            v.resize(stk_count);
+        }
     }
-    global_parallel_for_index_void(
-      0, stk_count, [this, &null_ind, &use_style_inds, fill_null](size_t i) {
-          const auto& stk = m_stks[i];
-          auto kdata = stk.getKData(m_query);
-          for (auto& [style_ind_name, styles] : m_special_style_inds) {
-              auto& cur_style_inds = use_style_inds[style_ind_name];
-              if (kdata.size() == 0) {
-                  for (size_t j = 0; j < styles.size(); j++) {
-                      cur_style_inds[j] = null_ind;
-                      cur_style_inds[j].name(style_ind_name);
-                  }
-              } else {
-                  for (size_t j = 0; j < styles.size(); j++) {
-                      cur_style_inds[j] =
-                        ALIGN(styles[j], m_ref_dates, fill_null)(kdata).getResult(0);
-                      cur_style_inds[j].name(style_ind_name);
-                  }
-              }
-          }
-      });
+    if (!m_special_style_inds.empty()) {
+        global_parallel_for_index_void(0, stk_count, [&](size_t si) {
+            const auto& stk = m_stks[si];
+            auto kdata = stk.getKData(m_query);
+            for (auto& [style_ind_name, styles] : m_special_style_inds) {
+                auto& per_factor = use_style_inds[style_ind_name];
+                for (size_t j = 0; j < styles.size(); j++) {
+                    if (kdata.size() == 0) {
+                        per_factor[j][si] = null_ind;
+                    } else {
+                        // 每线程独立 clone：calculate 只写本线程副本的 buffer
+                        per_factor[j][si] =
+                          ALIGN(styles[j].clone(), m_ref_dates, fill_null)(kdata).getResult(0);
+                    }
+                    per_factor[j][si].name(style_ind_name);
+                }
+            }
+        });
+    }
 
     // 时间截面标准化/归一化
     if (m_norm || !m_special_category.empty() || !m_special_style_inds.empty()) {
+        // 压制 Eigen 内部 OpenMP 并行，避免与外层按日线程池叠加导致线程超载；
+        // calculate_residuals 内的 Eigen 矩阵均为栈局部对象，外层按日并行天然可重入。
+        Eigen::setNbThreads(1);
         unordered_map<string, PriceList> ind_dummy_dict = _buildDummyIndex();
         global_parallel_for_index_void(
           0, days_total,
@@ -732,12 +754,14 @@ vector<IndicatorList> MultiFactorBase::getAllSrcFactors() {
                   }
                   auto style_iter = use_style_inds.find(ind_name);
                   if (style_iter != use_style_inds.end()) {
-                      vector<PriceList> style_value_day(style_iter->second.size());
-                      for (size_t j = 0; j < style_iter->second.size(); j++) {
+                      auto& per_factor = style_iter->second;  // [风格因子][股票]
+                      vector<PriceList> style_value_day(per_factor.size());
+                      for (size_t j = 0; j < per_factor.size(); j++) {
                           auto& style_value = style_value_day[j];
                           style_value.resize(stk_count);
                           for (size_t si = 0; si < stk_count; si++) {
-                              style_value[si] = style_iter->second[j][di];
+                              // 取第 si 只股票自己的风格因子值（原实现误取共享值）
+                              style_value[si] = per_factor[j][si][di];
                           }
                       }
                       new_value = calculate_residuals(new_value, style_value_day);


### PR DESCRIPTION
## 问题概述

`MultiFactorBase::getAllSrcFactors()` 的风格因子提取逻辑存在 **两个独立缺陷**，启用风格因子中性化（`add_special_normalize(style_inds=...)`）后，调用 `get_ic()` / `get_all_src_factors()` / `get_scores()` 等任何触发 `calculate()` 的接口，进程会直接 **segfault 崩溃（无 Python 异常，绕过 except）**。

复现条件（实测）：
- `add_special_normalize(style_inds=[LIUTONGPAN()*CLOSE()])` 注入市值风格因子
- 随后调用 `mf.get_ic()`
- 与股票数 / 因子数无关，50 股 × 2 因子同样可复现

---

## 根因分析

### 缺陷 1：数据竞争（崩溃根因）

原实现中，风格因子存储为 `[风格因子名] → IndicatorList` 的二维结构：

```cpp
unordered_map<string, IndicatorList> use_style_inds;
// use_style_inds[style_ind_name][j] 是单一 Indicator 对象
global_parallel_for_index_void(0, stk_count, [&](size_t i) {
    ...
    cur_style_inds[j] = ALIGN(styles[j], m_ref_dates, fill_null)(kdata).getResult(0);
    // ⚠ 多线程并发写同一个 shared_ptr 对象 = C++ UB
});
```

多个工作线程并发对 **同一个** `Indicator`（`shared_ptr<IndicatorImp>` 对象本身）执行赋值操作。C++ 标准仅保证"不同 shared_ptr 对象指向同一控制块"的线程安全，**不保证**"对同一个 shared_ptr 对象的并发写"是安全的。这是未定义行为，会导致指针撕裂 → segfault。

### 缺陷 2：数学错误（中性化静默失效）

即使不崩溃，风格因子的截面数据也是错的。原实现中所有股票共享同一条风格因子时序：

```cpp
// 原下游消费代码
for (size_t si = 0; si < stk_count; si++) {
    style_value[si] = style_iter->second[j][di];  // 所有 si 取同一个值
}
```

这导致截面回归的自变量矩阵中，风格因子列对所有股票取 **同一个常数**，与截距项（全 1 列）完全共线，矩阵奇异 → 市值 / 风格中性化在数学上彻底失效（残差 ≈ 原值，中性化等于没做）。

---

## 修复方案

### 1. 数据结构升维：`[风格因子名] → [风格因子][股票]`

```cpp
// 旧: unordered_map<string, IndicatorList>          // [风格因子]
// 新: unordered_map<string, vector<IndicatorList>>   // [风格因子][股票]
```

补上股票维度，每个风格因子为每只股票各保存一条对齐后的时序 Indicator。

### 2. 写隔离 + 读隔离（双重复并发保护）

**写隔离**：每个 `si` 线程只写 `per_factor[j][si]`，不同 `si` 写不同槽位，零写竞争。

**读隔离**：每线程对模板 `styles[j]` 先 `clone()` 出独立副本，再 `ALIGN(...)(kdata)` 计算：

```cpp
global_parallel_for_index_void(0, stk_count, [&](size_t si) {
    ...
    per_factor[j][si] = ALIGN(styles[j].clone(), m_ref_dates, fill_null)(kdata).getResult(0);
});
```

`ALIGN(styles[j], ...)(kdata)` 展开为 `operator()(Indicator)`，内部通过 `add(OP, nullptr, styles[j].getImp())` **共享引用** `styles[j]` 的 `IndicatorImp`。随后 `calculate()` 走 OP 分支会调用 `m_right->calculate()`，**写 `styles[j]` 的缓冲区**。因此多线程直接共享 `styles[j]` 并发 `calculate()` 会触发读侧缓冲区竞争。

通过每线程 `styles[j].clone()` 深拷贝整树（含独立 buffer），`calculate()` 只写本线程副本的 buffer，不触碰共享的 `styles[j]`。

**`clone()` 并发安全性已经代码核实**：`IndicatorImp::clone()`（`IndicatorImp.cpp:397-460`）所有赋值操作左值均为克隆体 `p->...`，源对象 `this` 只出现在右值（读）或作为地址常量；`shared_ptr` 拷贝触发的是控制块原子引用计数（C++ 标准保证线程安全）。因此多个线程并发对同一个根 `Indicator` 调用 `clone()` 是安全的。

### 3. 下游截面回归修正

```cpp
// 旧: style_value[si] = style_iter->second[j][di];        // 所有股票取同一值
// 新: style_value[si] = per_factor[j][si][di];             // 取第 si 只股票的值
```

恢复截面方差，市值 / 风格中性化在数学上真正生效。

### 4. Phase 3 逐日中性化保持并行 + Eigen 线程压制

逐日中性化循环 **保持原版按日并行**（不降级为串行），仅入口处加 `Eigen::setNbThreads(1)` 压制 Eigen 内部 OpenMP，避免与外层线程池叠加导致线程超载（oversubscription）。`calculate_residuals` 内的 `Eigen::MatrixXd` / `VectorXd` 均为栈局部对象，外层按日并行天然可重入。

---

## 验证

### 编译
- MSVC 2022 + xmake，release 构建，编译通过（`build ok`）。

### 功能验证
测试场景：`MF_ICIRWeight` + `market_cap_neutral=True` + `get_ic()` / `get_icir()`（原崩溃路径）。

```
[step3] === trigger crash path: get_ic() + get_icir() ===
[step3] OK: ic.len=300, icir.len=300          ← 原实现在此 segfault

[step4] verify style factor has cross-sectional variance ...
  last-day cross-section (all stocks): n=20, std=0.9747, range=[-1.7855, 1.3848]
  ✅ cross-section has variance → neutralization mathematically effective

[done] ALL CHECKS PASSED — no crash, math correct
```

- **不崩溃**：`get_ic()` / `get_icir()` 正常返回，原实现在此 segfault。
- **数学正确**：风格因子截面方差 `std=0.97`（原实现 ≈ 0，中性化失效）。

---

## 改动范围

单文件，单函数，`+50 / -26` 行：

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp` | `getAllSrcFactors()` 风格因子提取 + 下游消费 |

- 不改任何 API 签名 / 返回类型，外部无感知。
- 不改算法逻辑，仅修数据结构维度 + 并发安全性 + Eigen 线程配置。
- 唯一行为变化：风格中性化从"静默失效"变为"真正生效"（这是修 bug，不是改契约）。

> **⚠️ BREAKING CHANGE (数据模型变更警告)**：
> 原版本多因子库在执行风格截面中性化时，输出结果在数学上为无效的恒等序列（残差退化）。此 PR 修复该代数漏洞后，风格中性化结果将发生根本性改变（恢复正确的截面方差）。任何依赖旧版本风格中性化产出数据的策略模型，其原有回测结论均建立在错误数据之上，必须全部废弃并重新计算。

---

## 性能影响

- Phase 2（风格提取）：保持并行，每线程多一次 `clone()`（深拷贝单条 Indicator 树，开销可忽略）。
- Phase 3（逐日中性化）：保持原版并行，无性能退化。
- `Eigen::setNbThreads(1)` 仅禁用 Eigen 内部 OpenMP，外层按日并行不受影响。