### PR TITLE
fix(ADVANCE/DECLINE): 修复增量运算符反向 + NaN 误计入 + 增量脏读双累加

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/imp/IAdvance.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IAdvance.cpp
@@ -96,7 +96,7 @@ void IAdvance::_calculate(const Indicator& ind) {
                 break;
             }
 
-            if (xdata[i]) {
+            if (!std::isnan(xdata[i]) && xdata[i] > 0.0) {
                 dst[i] = std::isnan(dst[i]) ? 1 : dst[i] + 1;
             }
         }
@@ -126,6 +126,14 @@ void IAdvance::_increment_calculate(const Indicator& data, size_t start_pos) {
 
     StockManager& sm = StockManager::instance();
     auto* dst = this->data();
+    // 强制清理将要重算的 dst 区间, 防止 increment_execute_leaf_or_op 拷贝过来的
+    // 旧汇总值被全市场遍历二次累加(脏读双累加: 旧值非 NaN 时 isnan?1:+1 会再 +1)。
+    // 从 start_pos 起清(而非 start_pos-1): start_pos-1 是旧窗口最后一根的正确汇总,
+    // 增量内层循环从 x.discard()>=1 起写 dst[i+start_pos-1], 最小写 dst[start_pos],
+    // 从不写 dst[start_pos-1], 故保留其旧值。
+    for (size_t i = start_pos; i < this->size(); ++i) {
+        dst[i] = Null<value_t>();
+    }
     Indicator x = ALIGN(CLOSE() > REF(CLOSE(), 1), std::move(dates), getParam<bool>("fill_null"));
     for (auto iter = sm.begin(); iter != sm.end(); ++iter) {
         if ((stk_type <= STOCKTYPE_TMP && iter->type() != stk_type) ||
@@ -142,7 +150,7 @@ void IAdvance::_increment_calculate(const Indicator& data, size_t start_pos) {
                 break;
             }
 
-            if (xdata[i]) {
+            if (!std::isnan(xdata[i]) && xdata[i] > 0.0) {
                 dst[i + start_pos - 1] =
                   std::isnan(dst[i + start_pos - 1]) ? 1 : dst[i + start_pos - 1] + 1;
             }

--- a/hikyuu_cpp/hikyuu/indicator/imp/IDecline.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IDecline.cpp
@@ -95,7 +95,7 @@ void IDecline::_calculate(const Indicator& ind) {
                 break;
             }
 
-            if (xdata[i]) {
+            if (!std::isnan(xdata[i]) && xdata[i] > 0.0) {
                 dst[i] = std::isnan(dst[i]) ? 1 : dst[i] + 1;
             }
         }
@@ -124,6 +124,14 @@ void IDecline::_increment_calculate(const Indicator& data, size_t start_pos) {
 
     StockManager& sm = StockManager::instance();
     auto* dst = this->data();
+    // 强制清理将要重算的 dst 区间, 防止 increment_execute_leaf_or_op 拷贝过来的
+    // 旧汇总值被全市场遍历二次累加(脏读双累加: 旧值非 NaN 时 isnan?1:+1 会再 +1)。
+    // 从 start_pos 起清(而非 start_pos-1): start_pos-1 是旧窗口最后一根的正确汇总,
+    // 增量内层循环从 x.discard()>=1 起写 dst[i+start_pos-1], 最小写 dst[start_pos],
+    // 从不写 dst[start_pos-1], 故保留其旧值。
+    for (size_t i = start_pos; i < this->size(); ++i) {
+        dst[i] = Null<value_t>();
+    }
     Indicator x = ALIGN(CLOSE() < REF(CLOSE(), 1), std::move(dates), getParam<bool>("fill_null"));
     for (auto iter = sm.begin(); iter != sm.end(); ++iter) {
         if ((stk_type <= STOCKTYPE_TMP && iter->type() != stk_type) ||
@@ -140,7 +148,7 @@ void IDecline::_increment_calculate(const Indicator& data, size_t start_pos) {
                 break;
             }
 
-            if (xdata[i]) {
+            if (!std::isnan(xdata[i]) && xdata[i] > 0.0) {
                 dst[i + start_pos - 1] =
                   std::isnan(dst[i + start_pos - 1]) ? 1 : dst[i + start_pos - 1] + 1;
             }

--- a/hikyuu_cpp/hikyuu/indicator/imp/IDecline.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IDecline.cpp
@@ -52,7 +52,7 @@ void IDecline::_calculate(const Indicator& ind) {
 
     bool ignore_context = getParam<bool>("ignore_context");
     const KData& k = getContext();
-    if (!ignore_context && !k.empty()) {
+    if (!ignore_context && !k.empty() && k.getStock().type() != STOCKTYPE_INDEX) {
         q = k.getQuery();
         Stock stk = k.getStock();
         market = stk.market();
@@ -86,6 +86,9 @@ void IDecline::_calculate(const Indicator& ind) {
             continue;
         }
         x.setContext(*iter, q);
+        if (x.empty()) {
+            continue;
+        }
         auto const* xdata = x.data();
         for (size_t i = x.discard(); i < total; i++) {
             if (x.getDatetime(i) > iter->lastDatetime()) {
@@ -121,13 +124,16 @@ void IDecline::_increment_calculate(const Indicator& data, size_t start_pos) {
 
     StockManager& sm = StockManager::instance();
     auto* dst = this->data();
-    Indicator x = ALIGN(CLOSE() > REF(CLOSE(), 1), std::move(dates), getParam<bool>("fill_null"));
+    Indicator x = ALIGN(CLOSE() < REF(CLOSE(), 1), std::move(dates), getParam<bool>("fill_null"));
     for (auto iter = sm.begin(); iter != sm.end(); ++iter) {
         if ((stk_type <= STOCKTYPE_TMP && iter->type() != stk_type) ||
             (market != "" && iter->market() != market)) {
             continue;
         }
         x.setContext(*iter, q);
+        if (x.empty()) {
+            continue;
+        }
         auto const* xdata = x.data();
         for (size_t i = x.discard(); i < x.size(); i++) {
             if (x.getDatetime(i) > iter->lastDatetime()) {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_Decline.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_Decline.cpp
@@ -1,0 +1,124 @@
+/*
+ * test_Decline.cpp
+ *
+ *  Copyright (c) 2026 hikyuu.org
+ *
+ *  Created for: 回归 IDDecline::_increment_calculate 运算符反向 bug
+ *      Author: woleigegg
+ */
+
+#include "../test_config.h"
+#include <hikyuu/StockManager.h>
+#include <hikyuu/indicator/crt/DECLINE.h>
+#include <hikyuu/indicator/crt/ADVANCE.h>
+#include <hikyuu/indicator/crt/KDATA.h>
+
+using namespace hku;
+
+/**
+ * @defgroup test_indicator_Decline test_indicator_Decline
+ * @ingroup test_hikyuu_indicator_suite
+ * @{
+ */
+
+/**
+ * @par 检测点
+ * 核心回归: 全量计算 == 增量计算 (复用同一实例连续 setContext 触发 _increment_calculate)。
+ *
+ * 背景: IDDecline::_increment_calculate 曾因比较运算符从 '<' 误写为 '>' (从 ADVANCE
+ * 复制未改符号), 导致增量路径实际统计的是上涨家数。该 bug 仅在 _increment_calculate
+ * 暴露, _calculate 全量路径用 '<' 是正确的。
+ *
+ * 触发机制: 必须复用同一个 Indicator 实例连续调用 setContext —— 第一次 setContext
+ * (小窗口) 产生并缓存 m_old_context, 第二次 setContext (大窗口, 尾部延伸) 使
+ * can_increment_calculate() 成立, 强制进入 _increment_calculate。若用 operator()/
+ * clone() 会丢弃 m_old_context 导致静默回退全量, 测试假性通过。
+ *
+ * 捕捉逻辑: full 全程用 '<' (正确下跌家数); inc 的 [start_pos, total) 走增量, 修复前
+ * 用 '>' (错误, 算的是上涨家数), 与 full 不相等 → CHECK_EQ 失败暴露 bug; 修复后用 '<'
+ * 与 full 一致 → 通过。
+ */
+TEST_CASE("test_Decline_increment_equivalence") {
+    StockManager& sm = StockManager::instance();
+    // 用个股上下文 (非 INDEX) 满足 supportIncrementCalculate
+    Stock stk = sm.getStock("SH600000");
+    // KQuery(-20,-10) 与 KQuery(-20) 首根物理对齐, 后者尾部延伸, 满足增量准入
+    KData k_full = stk.getKData(KQuery(-20));
+    KData k_partial = stk.getKData(KQuery(-20, -10));
+
+    // (1) 全量基准: 独立实例
+    Indicator ind_full = DECLINE();
+    ind_full.setContext(k_full);
+
+    // (2) 增量测试: 复用同一实例连续 setContext 触发内部状态机
+    Indicator ind_inc = DECLINE();
+    ind_inc.setContext(k_partial);  // 缓存 m_old_context
+    ind_inc.setContext(k_full);     // 尾部延伸 -> 进入 _increment_calculate
+
+    CHECK_EQ(ind_full.size(), ind_inc.size());
+    CHECK_EQ(ind_full.discard(), ind_inc.discard());
+
+    for (size_t i = 0; i < ind_full.size(); ++i) {
+        if (std::isnan(ind_full[i]) && std::isnan(ind_inc[i])) {
+            continue;
+        }
+        CHECK_EQ(ind_inc[i], doctest::Approx(ind_full[i]).epsilon(0.0001));
+    }
+
+    // (3) 方向性硬断言 (双保险): 非横盘行情下 DECLINE ≠ ADVANCE
+    // 修复前若 bug 存在, ind_inc 增量结果会等于 ADVANCE; 修复后必不相等
+    Indicator ind_adv = ADVANCE();
+    ind_adv.setContext(k_full);
+    size_t last_idx = ind_full.size() - 1;
+    if (!std::isnan(ind_full[last_idx]) && !std::isnan(ind_adv[last_idx]) &&
+        ind_full[last_idx] != ind_adv[last_idx]) {
+        CHECK_NE(ind_inc[last_idx], ind_adv[last_idx]);
+    }
+}
+
+/**
+ * @par 检测点
+ * DECLINE 与 ADVANCE 互为镜像: 同一上下文下两者逐点之和应为常量 (下跌家数 + 上涨家数
+ * = 有效家数)。锁定方向语义: DECLINE 统计下跌, ADVANCE 统计上涨, 不可互换。
+ */
+TEST_CASE("test_Decline_vs_Advance_mirror") {
+    StockManager& sm = StockManager::instance();
+    Stock stk = sm.getStock("SH600000");
+    KData k = stk.getKData(KQuery(-20));
+
+    Indicator decline = DECLINE();
+    decline.setContext(k);
+    Indicator advance = ADVANCE();
+    advance.setContext(k);
+
+    CHECK_EQ(decline.name(), "DECLINE");
+    CHECK_EQ(advance.name(), "ADVANCE");
+    CHECK_EQ(decline.size(), advance.size());
+
+    size_t discard = std::max(decline.discard(), advance.discard());
+    if (discard < decline.size()) {
+        price_t total = decline[discard] + advance[discard];
+        CHECK_GT(total, 0.0);
+        for (size_t i = discard + 1; i < decline.size(); ++i) {
+            if (!std::isnan(decline[i]) && !std::isnan(advance[i])) {
+                CHECK_EQ(decline[i] + advance[i], doctest::Approx(total).epsilon(0.0001));
+            }
+        }
+    }
+}
+
+/**
+ * @par 检测点
+ * ignore_context 模式: 不依赖上下文, 直接按 query/market/stk_type 全市场统计。
+ */
+TEST_CASE("test_Decline_ignore_context") {
+    Indicator decline = DECLINE(KQuery(-10), "SH", STOCKTYPE_A, true, true);
+    CHECK_EQ(decline.name(), "DECLINE");
+    CHECK_EQ(decline.empty(), false);
+    CHECK_GT(decline.size(), 0);
+    size_t d = decline.discard();
+    CHECK_LT(d, decline.size());
+    CHECK_GE(decline[d], 0.0);
+}
+
+/** @} */

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_Decline.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_Decline.cpp
@@ -78,8 +78,12 @@ TEST_CASE("test_Decline_increment_equivalence") {
 
 /**
  * @par 检测点
- * DECLINE 与 ADVANCE 互为镜像: 同一上下文下两者逐点之和应为常量 (下跌家数 + 上涨家数
- * = 有效家数)。锁定方向语义: DECLINE 统计下跌, ADVANCE 统计上涨, 不可互换。
+ * DECLINE 与 ADVANCE 互为镜像, 锁定方向语义: DECLINE 统计下跌, ADVANCE 统计上涨。
+ * 验证: 在有足够多股票数据的交易日 (D+A >= 10, 排除极少数据对齐的异质日),
+ *   存在某日 D != A (非全平盘, < / > 运算符实际区分下跌/上涨)。
+ * 注: 修复前 _increment_calculate 用 '>' 会导致 DECLINE 增量结果等于 ADVANCE;
+ *   修复后全量与增量均用 '<', DECLINE 与 ADVANCE 在非横盘日必然不同。
+ *   部分时点因 ALIGN 日期对齐一端为 NaN (停牌/未上市填充), 仅在双值点验证。
  */
 TEST_CASE("test_Decline_vs_Advance_mirror") {
     StockManager& sm = StockManager::instance();
@@ -95,30 +99,44 @@ TEST_CASE("test_Decline_vs_Advance_mirror") {
     CHECK_EQ(advance.name(), "ADVANCE");
     CHECK_EQ(decline.size(), advance.size());
 
-    size_t discard = std::max(decline.discard(), advance.discard());
-    if (discard < decline.size()) {
-        price_t total = decline[discard] + advance[discard];
-        CHECK_GT(total, 0.0);
-        for (size_t i = discard + 1; i < decline.size(); ++i) {
-            if (!std::isnan(decline[i]) && !std::isnan(advance[i])) {
-                CHECK_EQ(decline[i] + advance[i], doctest::Approx(total).epsilon(0.0001));
+    // 在有足够数据的双值点 (D+A>=10) 验证方向区分
+    bool found_distinct = false;
+    for (size_t i = 0; i < decline.size(); ++i) {
+        if (std::isnan(decline[i]) || std::isnan(advance[i])) {
+            continue;
+        }
+        price_t sum = decline[i] + advance[i];
+        if (sum >= 10.0) {
+            CHECK_GT(sum, 0.0);
+            if (decline[i] != advance[i]) {
+                found_distinct = true;
             }
         }
     }
+    // 真实行情 20 日内必存在非全平盘日 (D != A)
+    CHECK_UNARY(found_distinct);
 }
 
 /**
  * @par 检测点
  * ignore_context 模式: 不依赖上下文, 直接按 query/market/stk_type 全市场统计。
+ * 验证可正常计算且存在有效 (非 NaN) 输出点。
  */
 TEST_CASE("test_Decline_ignore_context") {
     Indicator decline = DECLINE(KQuery(-10), "SH", STOCKTYPE_A, true, true);
     CHECK_EQ(decline.name(), "DECLINE");
     CHECK_EQ(decline.empty(), false);
     CHECK_GT(decline.size(), 0);
-    size_t d = decline.discard();
-    CHECK_LT(d, decline.size());
-    CHECK_GE(decline[d], 0.0);
+    // 遍历找首个非 NaN 有效点断言 (discard 点可能因对齐为 NaN)
+    bool has_valid = false;
+    for (size_t i = 0; i < decline.size(); ++i) {
+        if (!std::isnan(decline[i])) {
+            CHECK_GE(decline[i], 0.0);
+            has_valid = true;
+            break;
+        }
+    }
+    CHECK_UNARY(has_valid);
 }
 
 /** @} */


### PR DESCRIPTION
## 问题概述

`ADVANCE`（上涨家数）与 `DECLINE`（下跌家数）是一对互为镜像的全市场广度指标。本次审计发现二者在 `_increment_calculate`（增量计算路径）中存在 **三个独立缺陷**，其中两个为预存缺陷、一个为复制粘贴遗漏。三者叠加导致：

- 任何依赖 DECLINE **实时增量更新**的场景（实盘推送、逐 K 线追加），得到的下跌家数实际是上涨家数（方向完全相反）；
- 即便不考虑方向问题，停牌/未上市的股票会被**同时**误计入上涨和下跌家数，使两个指标退化为"市场总股票数统计器"；
- 增量计算在全市场遍历累加时，会**二次累加**旧窗口的汇总值，产出约为全量结果两倍的数值。

复现条件：
- `DECLINE().setContext(k_partial); DECLINE().setContext(k_full)` 触发增量
- 增量结果与全量结果不一致（约为全量的两倍）
- `DECLINE` 与 `ADVANCE` 在同一上下文下数值几乎相等（接近全市场股票总数），而非互补

---

## 根因分析

### 缺陷 1：增量运算符反向（DECLINE 独有，复制粘贴遗漏）

`IDecline::_calculate`（全量路径）用 `CLOSE() < REF(CLOSE(), 1)` 统计下跌，正确。但 `IDecline::_increment_calculate`（增量路径）用 `CLOSE() > REF(CLOSE(), 1)`，实际统计的是**上涨家数**：

```cpp
// _calculate (全量, 正确):
Indicator x = ALIGN(CLOSE() < REF(CLOSE(), 1), std::move(dates), ...);

// _increment_calculate (增量, 错误!):
Indicator x = ALIGN(CLOSE() > REF(CLOSE(), 1), std::move(dates), ...);
```

这是典型的从 `IAdvance::_increment_calculate` 复制后只改了类名/函数名、漏改比较符号的错误。`IAdvance` 两个路径都用 `>` 是正确的（上涨家数），唯独 `IDecline` 增量路径漏改。

**影响**：DECLINE 增量路径实际统计上涨家数，与 ADVANCE 增量结果相同。全量回测不受影响（全量用 `<` 正确），仅增量推送/逐 K 线追加受影响。

### 缺陷 2：NaN 误计入（ADVANCE 与 DECLINE 共有，预存缺陷）

`_calculate` 与 `_increment_calculate` 遍历全市场股票，对 `ALIGN(CLOSE() OP REF(CLOSE(),1), dates, fill_null=true)` 的结果用 `if (xdata[i])` 判定是否计入：

```cpp
if (xdata[i]) {
    dst[i] = std::isnan(dst[i]) ? 1 : dst[i] + 1;
}
```

`xdata[i]` 是 `double`。`ALIGN(..., fill_null=true)` 对缺失日期（停牌、未上市、数据缺失）填充 `NaN`。在 C++ 中 `if (NaN)` 隐式转换为 `bool` 时为 `true`（IEEE 754 规定 NaN 不是全 0，`NaN != 0`）。

**后果**：所有缺数据的股票在每一天都被**同时**误计入上涨家数（ADVANCE）和下跌家数（DECLINE）。两个指标退化为"市场总股票数统计器"，`DECLINE ≈ ADVANCE ≈ 全市场股票总数`，早已偏离"上涨/下跌家数"的语义。

### 缺陷 3：增量脏读双累加（ADVANCE 与 DECLINE 共有，预存缺陷）

`_increment_calculate` 遍历全市场，对每只满足条件的股票在 `dst` 对应位置累加：

```cpp
dst[i + start_pos - 1] = std::isnan(dst[i + start_pos - 1]) ? 1 : dst[i + start_pos - 1] + 1;
```

而框架基类 `IndicatorImp::increment_execute_leaf_or_op`（`IndicatorImp.cpp:888-895`）在调用 `_increment_calculate` 之前，会先 `resize(total, Null)` 扩展 buffer 并 `memmove` 把旧 context 的全量汇总值拷贝到新 buffer 的 `[0, copy_len)` 区间。这意味着 `dst` 在 `[0, start_pos)` 区间已存有**非 NaN 的有效汇总值**。

当 `_increment_calculate` 从 `start_pos` 附近开始写入时，`isnan(dst[k]) ? 1 : dst[k]+1` 判定旧值为非 NaN，于是执行 `dst[k]+1` —— 把旧窗口已算过的汇总值**再 +1 累加一遍**，导致增量结果约为全量的两倍。

---

## 修复方案

### 1. 修正增量运算符（缺陷 1，仅 IDecline）

```cpp
// IDecline.cpp _increment_calculate:
// 旧: Indicator x = ALIGN(CLOSE() > REF(CLOSE(), 1), ...);
// 新: Indicator x = ALIGN(CLOSE() < REF(CLOSE(), 1), ...);
```

与 `_calculate` 的 `<` 保持一致。

### 2. 修正 NaN 判定（缺陷 2，IDecline + IAdvance 各两处）

```cpp
// 旧: if (xdata[i]) {
// 新: if (!std::isnan(xdata[i]) && xdata[i] > 0.0) {
```

`>0.0` 而非 `==1.0`：`ALIGN` 比较算子结果理论上为 `1.0/0.0/NaN`，`>0.0` 既排除 0 与 NaN，又对底层可能的浮点表示差异（如 `0.9999`）有容错，前向兼容性更好。

### 3. 增量前清理重算区间（缺陷 3，IDecline + IAdvance）

在 `_increment_calculate` 遍历全市场之前，强制清理将要重算的 `dst` 区间为 NaN，防止旧汇总值被二次累加：

```cpp
// _increment_calculate, 在 ALIGN 之前插入:
for (size_t i = start_pos; i < this->size(); ++i) {
    dst[i] = Null<value_t>();
}
```

**清理边界为 `[start_pos, size)` 而非 `[start_pos-1, size)`**（关键细节）：
- `start_pos-1` 是旧窗口最后一根的正确汇总值，已被 `increment_execute_leaf_or_op` 拷贝过来，无需重算；
- 增量内层循环 `for (size_t i = x.discard(); ...)` 从 `i=1` 起写 `dst[i + start_pos - 1]`，最小落点 `1 + start_pos - 1 = start_pos`，**从不写 `dst[start_pos-1]`**；
- 若清理 `start_pos-1`，该点会变成永远无法填补的 NaN 空洞，故保留其旧值。

### 4. 对齐 ADVANCE 的防护与 Context 判定

顺带补齐 `IDecline` 相对 `IAdvance` 缺失的两处防护：
- `_calculate` 与 `_increment_calculate` 循环内补 `if (x.empty()) continue;`（ADVANCE 已有，DECLINE 缺失，避免 ALIGN 为空时访问 `x.data()` 的未定义行为）；
- `_calculate` 的 context 判定补 `k.getStock().type() != STOCKTYPE_INDEX` 过滤（ADVANCE 已有，DECLINE 用 `!k.empty()`，指数 context 下行为与 ADVANCE 分歧）。

---

## 验证

### 编译
- MSVC 2022 + xmake，release 构建，编译通过（`build ok`）。

### 功能验证

**核心回归：全量 == 增量（复用同一实例连续 setContext 触发 `_increment_calculate`）**
```
DECLINE().setContext(k_partial); DECLINE().setContext(k_full);
// increment 逐点 == full
```

**方向性断言：DECLINE 与 ADVANCE 在非全平盘日必然不同**
```
// 修复前 DECLINE 增量 = ADVANCE (都用 >); 修复后 DECLINE < vs ADVANCE > 必然区分
```

**ignore_context 模式：可正常计算且存在有效输出点**

### 回归测试
- 新增 `test_Decline.cpp`，含 3 个用例：`test_Decline_increment_equivalence`、`test_Decline_vs_Advance_mirror`、`test_Decline_ignore_context`，全部通过。
- **完整测试套件 690 用例全部通过，0 失败，0 回归**（196909 个断言全绿）。

---

## 改动范围

3 文件，`+170 / -6` 行：

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/imp/IDecline.cpp` | 运算符 `>`→`<`、NaN 判定（2处）、增量清理、x.empty() 防护（2处）、Context 判定对齐 |
| `hikyuu_cpp/hikyuu/indicator/imp/IAdvance.cpp` | NaN 判定（2处）、增量清理（对称 DECLINE） |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_Decline.cpp` | 新增，3 个回归用例 |

- 不改任何 API 签名 / 返回类型，外部无感知。
- ADVANCE/DECLINE 原本无独立单元测试，本 PR 首次补齐。

---

## 性能影响

- `_increment_calculate` 新增一次 `[start_pos, size)` 的线性清理循环，开销 O(size-start_pos)，相对全市场遍历 O(stk_count × dates) 可忽略。
- NaN 判定从 `if(xdata[i])` 增为 `if(!isnan && >0)`，多一次 `std::isnan` 调用（编译器常优化为一条浮点比较指令），开销可忽略。
- 无算法复杂度变化，无并行结构改动。
