### PR TITLE
fix(multifactor): 行业中性化用组内去均值替代整数编码单变量回归 + 修复 ALIGN 改名导致路由静默失效

### DIFF
--- a/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp
@@ -20,6 +20,7 @@
 #include "hikyuu/indicator/crt/ZSCORE.h"
 #include "hikyuu/StockManager.h"
 #include "MultiFactorBase.h"
+#include "industry_neutralize.h"
 
 namespace hku {
 
@@ -483,11 +484,11 @@ Indicator MultiFactorBase::getICIR(int ir_n, int ic_n) {
     return x;
 }
 
-unordered_map<string, PriceList> MultiFactorBase::_buildDummyIndex() {
-    // 如果指定了特殊的指标的行业中性化处理，则构建其行业哑变量
-    unordered_map<string, PriceList> stock_dummy_index;
+unordered_map<string, std::pair<PriceList, size_t>> MultiFactorBase::_buildDummyIndex() {
+    // 如果指定了特殊的指标的行业中性化处理，则构建其行业归属标签
+    unordered_map<string, std::pair<PriceList, size_t>> stock_dummy_index;
     for (const auto& [ind_name, catefory] : m_special_category) {
-        stock_dummy_index[ind_name] = PriceList(m_stks.size(), Null<price_t>());
+        stock_dummy_index[ind_name] = {PriceList(m_stks.size(), Null<price_t>()), 0};
         auto blks = StockManager::instance().getBlockList(catefory);
         if (blks.empty()) {
             HKU_WARN("Block list ({}) is empty, please check your block category!", catefory);
@@ -495,9 +496,10 @@ unordered_map<string, PriceList> MultiFactorBase::_buildDummyIndex() {
         }
 
         auto iter = stock_dummy_index.find(ind_name);
-        auto& dummy = iter->second;
-
+        auto& dummy = iter->second.first;
         size_t blk_count = blks.size();
+        iter->second.second = blk_count;
+
         for (size_t i = 0; i < m_stks.size(); i++) {
             bool found = false;
             size_t j = 0;
@@ -510,6 +512,8 @@ unordered_map<string, PriceList> MultiFactorBase::_buildDummyIndex() {
                 j++;
             }
             if (!found) {
+                // 无归属股票赋 blk_count，下游组内去均值时跳过（残差置 NaN），
+                // 避免将其隐式聚成伪行业簇造成伪回归。
                 dummy[i] = blk_count;
             }
         }
@@ -525,52 +529,8 @@ IndicatorList MultiFactorBase::_getAllReturns(int ndays) const {
     });
 }
 
-// 计算中性化后的因子，y 为因子，x 为行业哑变量（包含常数项）
-static PriceList calculate_residuals(const PriceList& y, const PriceList& x) {
-    HKU_ASSERT(y.size() == x.size());
-
-    const size_t n = x.size();
-    PriceList residuals(n, Null<price_t>());
-
-    // 计算线性回归系数（带常数项）
-    double sum_x = 0.0, sum_y = 0.0, sum_xy = 0.0, sum_x2 = 0.0;
-    size_t count = 0;
-
-    for (size_t i = 0; i < n; ++i) {
-        if (std::isnan(x[i]) || std::isinf(x[i]) || std::isnan(y[i]) || std::isinf(y[i])) {
-            continue;
-        }
-        sum_x += x[i];
-        sum_y += y[i];
-        sum_xy += x[i] * y[i];
-        sum_x2 += x[i] * x[i];
-        count++;
-    }
-
-    // 数据点不足或分母为0
-    if (count < 2 || sum_x * sum_x - count * sum_x2 == 0) {
-        return residuals;
-    }
-
-    // 计算回归系数 β₀ (截距) 和 β₁ (斜率)
-    double beta1 = (sum_x * sum_y - count * sum_xy) / (sum_x * sum_x - count * sum_x2);
-    double beta0 = (sum_y - beta1 * sum_x) / count;
-
-    if (std::isnan(beta0) || std::isinf(beta0) || std::isnan(beta1) || std::isinf(beta1)) {
-        return residuals;
-    }
-
-    // 计算拟合值和残差
-    for (size_t i = 0; i < n; ++i) {
-        if (std::isnan(x[i]) || std::isinf(x[i]) || std::isnan(y[i]) || std::isinf(y[i])) {
-            continue;
-        }
-        double y_hat = beta0 + beta1 * x[i];  // 拟合值 = β₀ + β₁x
-        residuals[i] = y[i] - y_hat;          // 残差 = 观测值 - 拟合值
-    }
-
-    return residuals;
-}
+// 行业中性化（按行业分组去组内均值）的纯函数实现见 industry_neutralize.h，
+// 提取为内部 inline header 供白盒单元测试直接包含调用。
 
 // 计算多元回归中性化后的因子，y为因子，x为多个解释变量（包含常数项）- Eigen版本
 static PriceList calculate_residuals(const PriceList& y, const std::vector<PriceList>& x) {
@@ -718,7 +678,7 @@ vector<IndicatorList> MultiFactorBase::getAllSrcFactors() {
         // 压制 Eigen 内部 OpenMP 并行，避免与外层按日线程池叠加导致线程超载；
         // calculate_residuals 内的 Eigen 矩阵均为栈局部对象，外层按日并行天然可重入。
         Eigen::setNbThreads(1);
-        unordered_map<string, PriceList> ind_dummy_dict = _buildDummyIndex();
+        unordered_map<string, std::pair<PriceList, size_t>> ind_dummy_dict = _buildDummyIndex();
         global_parallel_for_index_void(
           0, days_total,
           [this, stk_count, ind_count, &all_stk_inds, &ind_dummy_dict, &use_style_inds](size_t di) {
@@ -732,7 +692,14 @@ vector<IndicatorList> MultiFactorBase::getAllSrcFactors() {
                       one_day_data[si] = all_stk_inds[si][ii][di];
                   }
 
-                  auto ind_name = all_stk_inds[0][ii].name();
+                  // 注：经 m_factorset.getValues(align=true) 产出的 all_stk_inds[*][ii]
+                  // 会被 ALIGN 套层改名为 "ALIGN"（运行时实证）。而 addSpecialNormalize
+                  // 存入 m_special_norms/m_special_category 的 key 是 FactorSet 里的因子
+                  // 原名（如 "MA"）。若取 all_stk_inds[0][ii].name() 做 find 的 key，永远
+                  // 不命中，行业/风格/特殊标准化全部静默失效。改用 m_factorset[ii].name()
+                  // 按下标溯源原名：getValues 产出 result[j][i] 严格对应 factors[i]，
+                  // 下标 ii 与 m_factorset[ii] 一一对应，无乱序风险。
+                  auto ind_name = m_factorset[ii].name();
                   auto special_norm_iter = m_special_norms.find(ind_name);
                   if (special_norm_iter != m_special_norms.end()) {
                       special_norm = special_norm_iter->second->clone();
@@ -750,7 +717,11 @@ vector<IndicatorList> MultiFactorBase::getAllSrcFactors() {
 
                   auto category_iter = ind_dummy_dict.find(ind_name);
                   if (category_iter != ind_dummy_dict.end()) {
-                      new_value = calculate_residuals(new_value, category_iter->second);
+                      // 行业中性化：组内去均值（O(n)，数学等价于去截距 one-hot 多元回归）。
+                      // 原实现误用单变量 calculate_residuals 对整数板块序号做一元回归，
+                      // 隐含"行业 j 的效应 = β0 + β1·j"的错误假设，结果依赖板块列表排列顺序。
+                      const auto& [labels, blk_count] = category_iter->second;
+                      new_value = calculate_industry_residuals(new_value, labels, blk_count);
                   }
                   auto style_iter = use_style_inds.find(ind_name);
                   if (style_iter != use_style_inds.end()) {

--- a/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.h
@@ -178,8 +178,10 @@ public:
 private:
     void initParam();
 
-    // 构造每个指标构造行业哑变量，以便进行行业中性化处理
-    unordered_map<string, PriceList> _buildDummyIndex();
+    // 构造每个指标的行业归属标签（整数板块序号）与板块数，以便进行行业中性化处理。
+    // 返回 {factor_name -> (labels, blk_count)}：
+    //   labels[i] = 股票 i 所属板块在 blks 中的下标（0..blk_count-1），无归属则为 blk_count。
+    unordered_map<string, std::pair<PriceList, size_t>> _buildDummyIndex();
 
     void _buildIndex();  // 计算完成后创建截面索引
 

--- a/hikyuu_cpp/hikyuu/trade_sys/multifactor/industry_neutralize.h
+++ b/hikyuu_cpp/hikyuu/trade_sys/multifactor/industry_neutralize.h
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2026 hikyuu.org
+ *
+ *  行业中性化的纯函数实现，提取为内部 inline header 以支持白盒单元测试。
+ *  MultiFactorBase.cpp 与 test_MF_IndustryNeutralize.cpp 共同包含此头文件。
+ */
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+#include "hikyuu/DataType.h"
+#include "hikyuu/utilities/Log.h"
+#include "hikyuu/utilities/Null.h"
+
+namespace hku {
+
+// 计算行业中性化后的因子：按行业分组去组内均值，残差 = y_i - mean(y_{group(i)})。
+//
+// 数学等价性：当行业归属互斥（一只股票只属一个行业）且仅对这一个分类变量做中性化时，
+// "去全局截距的 one-hot 多元回归取残差"严格等价于"组内去均值"：
+//   min_{β} Σ_i (y_i - Σ_k X_{i,k} β_k)^2  因 X 为互斥 one-hot，可拆成各行业独立求和，
+//   解析解 β_k = mean(y_{group(k)})，残差 e_i = y_i - mean(y_{group(i)})。
+// 故无需构造设计矩阵与 QR 分解，两趟扫描 O(n) 即可，且天然兼容每日动态 NaN 掩码
+// （算组内均值时跳过无效值），避免原整数编码 + 单变量回归的模型误设（结果依赖
+// 板块列表排列顺序）与多线程下 Eigen 矩阵堆分配争用。
+//
+// labels[i] = 股票 i 的行业下标（0..blk_count-1），无归属则为 blk_count（跳过，残差置 NaN）。
+inline PriceList calculate_industry_residuals(const PriceList& y, const PriceList& labels,
+                                              size_t blk_count) {
+    HKU_ASSERT(y.size() == labels.size());
+
+    const size_t n = y.size();
+    PriceList residuals(n, Null<price_t>());
+
+    // 全市场同行业（k=1）或无行业分类时，去均值退化为去全局均值；无有效数据则全 NaN。
+    if (blk_count == 0) {
+        return residuals;
+    }
+
+    std::vector<double> sums(blk_count, 0.0);
+    std::vector<size_t> counts(blk_count, 0);
+
+    // Pass 1: 累计各组有效 y 的和与计数（跳过 NaN/Inf 与无归属股票）
+    for (size_t i = 0; i < n; ++i) {
+        if (std::isnan(y[i]) || std::isinf(y[i])) {
+            continue;
+        }
+        double label = labels[i];
+        // 守卫 NaN/Inf/负数/超大值：static_cast<size_t>(负数) 是 UB，
+        // 可能溢出为 SIZE_MAX 导致 sums[g] 越界段错误，必须在 cast 前用 double 比较拦截。
+        if (std::isnan(label) || std::isinf(label) || label < 0.0 ||
+            label >= static_cast<double>(blk_count)) {
+            continue;  // 无归属或非法标签不参与组内均值
+        }
+        size_t g = static_cast<size_t>(label);
+        sums[g] += y[i];
+        counts[g]++;
+    }
+
+    // Pass 2: 残差 = y_i - mean(y_{group(i)})
+    for (size_t i = 0; i < n; ++i) {
+        if (std::isnan(y[i]) || std::isinf(y[i])) {
+            continue;  // 保留 NaN（与原 calculate_residuals 语义一致）
+        }
+        double label = labels[i];
+        if (std::isnan(label) || std::isinf(label) || label < 0.0 ||
+            label >= static_cast<double>(blk_count)) {
+            continue;  // 无归属或非法标签：残差置 NaN
+        }
+        size_t g = static_cast<size_t>(label);
+        if (counts[g] == 0) {
+            continue;  // 该组无有效样本：残差置 NaN
+        }
+        residuals[i] = y[i] - sums[g] / static_cast<double>(counts[g]);
+    }
+
+    return residuals;
+}
+
+}  // namespace hku

--- a/hikyuu_cpp/unit_test/hikyuu/trade_sys/multifactor/test_MF_IndustryNeutralize.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/trade_sys/multifactor/test_MF_IndustryNeutralize.cpp
@@ -1,0 +1,204 @@
+/*
+ * test_MF_IndustryNeutralize.cpp
+ *
+ * 行业中性化的白盒单元测试 + 端到端路由验证。
+ *
+ *   - 白盒用例直接测试 calculate_industry_residuals 纯函数（经 industry_neutralize.h
+ *     inline 暴露），构造 PriceList 验证数学性质，无任何外部数据依赖。
+ *   - E2E 用例验证 _buildDummyIndex -> calculate_industry_residuals 的路由连通性，
+ *     依赖 test_data/block/hybk.ini（中文板块名，需 supportChineseSimple）。
+ */
+
+#include "../../test_config.h"
+#include <hikyuu/StockManager.h>
+#include <hikyuu/indicator/crt/MA.h>
+#include <hikyuu/indicator/crt/KDATA.h>
+#include <hikyuu/utilities/runtimeinfo.h>
+#include <hikyuu/trade_sys/multifactor/MultiFactorBase.h>
+#include <hikyuu/trade_sys/multifactor/buildin_norm.h>
+#include <hikyuu/trade_sys/multifactor/industry_neutralize.h>
+#include <hikyuu/trade_sys/multifactor/crt/MF_EqualWeight.h>
+
+using namespace hku;
+
+/**
+ * @defgroup test_MF_IndustryNeutralize test_MF_IndustryNeutralize
+ * @ingroup test_hikyuu_trade_sys_suite
+ * @{
+ */
+
+//-----------------------------------------------------------------------------
+// 白盒测试：calculate_industry_residuals 纯函数
+//-----------------------------------------------------------------------------
+
+/** @par 置换不变性 —— 核心反例，锁定本次 bug 修复
+ *  行业中性化结果必须与板块编号方式无关。原实现对整数编号做单变量回归，
+ *  重排板块列表会改变残差；组内去均值则不受编号影响。
+ */
+TEST_CASE("test_industry_residuals_permutation_invariance") {
+    PriceList y{10.0, 20.0, 30.0, 40.0};
+    size_t blk_count = 2;
+
+    // 场景 A：组 0 = {10,20}(均值15)，组 1 = {30,40}(均值35)
+    PriceList labelsA{0.0, 0.0, 1.0, 1.0};
+    auto resA = calculate_industry_residuals(y, labelsA, blk_count);
+    CHECK_EQ(resA.size(), y.size());
+    CHECK_EQ(resA[0], doctest::Approx(-5.0).epsilon(1e-9));
+    CHECK_EQ(resA[1], doctest::Approx(5.0).epsilon(1e-9));
+    CHECK_EQ(resA[2], doctest::Approx(-5.0).epsilon(1e-9));
+    CHECK_EQ(resA[3], doctest::Approx(5.0).epsilon(1e-9));
+
+    // 场景 B：完全颠倒行业编号 —— 残差必须与 A 完全一致
+    PriceList labelsB{1.0, 1.0, 0.0, 0.0};
+    auto resB = calculate_industry_residuals(y, labelsB, blk_count);
+    for (size_t i = 0; i < y.size(); i++) {
+        CHECK_EQ(resB[i], doctest::Approx(resA[i]).epsilon(1e-9));
+    }
+}
+
+/** @par 边界：行业孤儿（无归属）与标签 NaN —— 残差置 NaN，不参与组内均值 */
+TEST_CASE("test_industry_residuals_orphan_and_nan_label") {
+    PriceList y{10.0, 20.0, 30.0};
+    size_t blk_count = 2;
+    // 索引1: label=2 >= blk_count (孤儿)；索引2: 标签 NaN
+    PriceList labels{0.0, 2.0, Null<price_t>()};
+    auto res = calculate_industry_residuals(y, labels, blk_count);
+
+    // 索引0: 组0 仅自身，残差 = 10 - 10 = 0
+    CHECK_EQ(res[0], doctest::Approx(0.0).epsilon(1e-9));
+    // 孤儿与标签缺失：残差 NaN
+    CHECK_UNARY(std::isnan(res[1]));
+    CHECK_UNARY(std::isnan(res[2]));
+}
+
+/** @par 边界：k=1 全市场同行业 —— 退化为去全局均值 */
+TEST_CASE("test_industry_residuals_single_group_global_mean") {
+    PriceList y{10.0, 20.0, 30.0};
+    size_t blk_count = 1;
+    PriceList labels{0.0, 0.0, 0.0};
+    auto res = calculate_industry_residuals(y, labels, blk_count);
+    // 全局均值 = 20，残差 = {-10, 0, 10}
+    CHECK_EQ(res[0], doctest::Approx(-10.0).epsilon(1e-9));
+    CHECK_EQ(res[1], doctest::Approx(0.0).epsilon(1e-9));
+    CHECK_EQ(res[2], doctest::Approx(10.0).epsilon(1e-9));
+}
+
+/** @par 边界：同行业含无效数据 —— 算组内均值时跳过 NaN，残差对无效点置 NaN */
+TEST_CASE("test_industry_residuals_group_with_invalid_y") {
+    PriceList y{10.0, Null<price_t>(), 20.0};
+    size_t blk_count = 1;
+    PriceList labels{0.0, 0.0, 0.0};
+    auto res = calculate_industry_residuals(y, labels, blk_count);
+    // 有效组内均值 = (10+20)/2 = 15
+    CHECK_EQ(res[0], doctest::Approx(-5.0).epsilon(1e-9));
+    CHECK_UNARY(std::isnan(res[1]));
+    CHECK_EQ(res[2], doctest::Approx(5.0).epsilon(1e-9));
+}
+
+/** @par 边界：全 NaN/Inf 输入 —— 不崩溃，不抛浮点异常，返回全 NaN */
+TEST_CASE("test_industry_residuals_all_invalid") {
+    PriceList y{Null<price_t>(), std::numeric_limits<price_t>::infinity(),
+                -std::numeric_limits<price_t>::infinity()};
+    size_t blk_count = 2;
+    PriceList labels{0.0, 0.0, 1.0};
+    auto res = calculate_industry_residuals(y, labels, blk_count);
+    CHECK_EQ(res.size(), y.size());
+    for (size_t i = 0; i < y.size(); i++) {
+        CHECK_UNARY(std::isnan(res[i]));
+    }
+}
+
+/** @par 边界：负数/超大标签 —— 守卫 static_cast<size_t> 的 UB，不崩溃不越界
+ *  static_cast<size_t>(负数) 是 C++ UB，可能溢出为 SIZE_MAX 导致 sums[g] 越界段错误。
+ *  实现须在 cast 前用 double 比较拦截 label<0 或 label>=blk_count。
+ */
+TEST_CASE("test_industry_residuals_negative_and_oversized_label") {
+    PriceList y{10.0, 20.0, 30.0, 40.0};
+    size_t blk_count = 2;
+    // label[0]=-1(负数UB风险), [1]=999(超大越界), [2]=0(合法), [3]=1(合法)
+    PriceList labels{-1.0, 999.0, 0.0, 1.0};
+    auto res = calculate_industry_residuals(y, labels, blk_count);
+    // 负数与超大标签：残差 NaN（不崩溃不越界）
+    CHECK_UNARY(std::isnan(res[0]));
+    CHECK_UNARY(std::isnan(res[1]));
+    // 合法标签：组0仅30（均值30，残差0），组1仅40（均值40，残差0）
+    CHECK_EQ(res[2], doctest::Approx(0.0).epsilon(1e-9));
+    CHECK_EQ(res[3], doctest::Approx(0.0).epsilon(1e-9));
+}
+
+//-----------------------------------------------------------------------------
+// E2E 路由验证：_buildDummyIndex -> calculate_industry_residuals 连通性
+//-----------------------------------------------------------------------------
+
+/** @par 端到端路由：启用行业中性化后，同一行业股票截面残差之和 ≈ 0
+ *  动态发现策略：遍历"行业板块"所有板块，找第一个含≥2只有效 K 线股票的板块
+ *  作为同行业探针对。不硬编码特定股票代码，CI 数据变动自动适配；若整个分类
+ *  无同行业对，REQUIRE 失败明确暴露数据不足，不静默通过。
+ *
+ *  注：测试环境用 QLBlockInfoDriver（读 ini），其 save 抛"Not support"，无法用
+ *  sm.addBlock 注入内存 Mock，故采用动态发现。
+ */
+TEST_CASE("test_mf_industry_neutralize_routing") {
+    if (!supportChineseSimple()) {
+        return;
+    }
+
+    StockManager& sm = StockManager::instance();
+    KQuery query = KQuery(-30);
+
+    // 动态发现一对同行业且有数据的股票
+    Stock stk_a, stk_b;
+    auto blks = sm.getBlockList("行业板块");
+    for (const auto& blk : blks) {
+        auto stocks = blk.getStockList();
+        Stock first, second;
+        for (const auto& s : stocks) {
+            if (s.isNull() || s.getKData(query).size() < 10) {
+                continue;
+            }
+            if (first.isNull()) {
+                first = s;
+            } else {
+                second = s;
+                break;
+            }
+        }
+        if (!second.isNull()) {
+            stk_a = first;
+            stk_b = second;
+            break;
+        }
+    }
+    REQUIRE_UNARY_FALSE(stk_a.isNull());
+    REQUIRE_UNARY_FALSE(stk_b.isNull());
+
+    Stock ref_stk = sm["sh000001"];
+    StockList stks{stk_a, stk_b};
+
+    IndicatorList src_inds{MA(CLOSE(), 5)};
+    auto mf = MF_EqualWeight(src_inds, stks, query, ref_stk);
+    mf->setParam<bool>("save_all_factors", true);
+    mf->setNormalize(NORM_NOTHING());
+    mf->addSpecialNormalize("MA", NORM_NOTHING(), "行业板块");
+
+    // 关键：必须先触发 calculate() 填充 m_ref_dates，否则 getAllSrcFactors() 因
+    // m_ref_dates 为空（days_total=0）跳过截面中性化循环，静默返回原始因子值。
+    mf->getDatetimeList();
+
+    auto all_src = mf->getAllSrcFactors();
+    CHECK_EQ(all_src.size(), stks.size());
+
+    auto ref_dates = mf->getDatetimeList();
+    REQUIRE_GT(ref_dates.size(), 5u);
+    size_t di = ref_dates.size() / 2;
+
+    // 反静默失效探针：同行业残差和≈0。若 name 路由匹配失败（ALIGN 改名导致
+    // m_special_category 不命中），输出原始 MA 值，两只不同股价 MA 之和不会为 0。
+    double r0 = all_src[0][0][di];
+    double r1 = all_src[1][0][di];
+    CHECK_UNARY_FALSE(std::isnan(r0));
+    CHECK_UNARY_FALSE(std::isnan(r1));
+    CHECK_EQ(r0 + r1, doctest::Approx(0.0).epsilon(1e-6));
+}
+
+/** @} */


### PR DESCRIPTION
## 问题概述

行业中性化（`addSpecialNormalize(category="行业板块")`）存在两个叠加缺陷：
1. **算法误设**：对每只股票赋整数板块序号，下游用单变量线性回归取残差。行业是 nominal 分类变量，整数无序关系，该实现结果依赖板块列表排列顺序（置换不变性破坏）。
2. **路由静默失效**：经 `getAllSrcFactors` 内部 `ALIGN` 处理后因子 name 变为 `"ALIGN"`，而 `addSpecialNormalize` 存入 `m_special_category` 的 key 是因子原名。热点循环用对齐后的 name 做 `find` 永远不命中，行业/风格/特殊标准化全部静默跳过。

两个缺陷叠加导致：启用 `industry_neutral=True` 时，行业中性化在数学上无效，且在路由上根本不触发，静默产出未中性化的原始因子值。不会崩溃。

## 根因分析

### 缺陷一：整数编码 + 单变量回归

`_buildDummyIndex()`（`MultiFactorBase.cpp:486`）对每只股票赋值板块在 `getBlockList` 返回列表中的下标 `0,1,2,...,blk_count`。下游 `calculate_residuals(y, x)`（单变量重载）做一元线性回归 `y = β0 + β1·x`，x 即整数编号。这隐含假设"行业 j 的效应 = β0 + β1·j"，即"行业 3 的效应是行业 1 的 3 倍"——在分类变量语境下无意义。重排 `blks` 列表，同一股票的编号改变，β1 含义改变，残差随之改变。

### 缺陷二：ALIGN 改名导致 name 路由失配

运行时实证（Python 实测 `ALIGN(applied, dates).name`）：

```
raw MA name: MA
ALIGN(applied) name: ALIGN   ← 改名
```

`getAllSrcFactors` 内部 `m_factorset.getValues(..., align=true, ...)` 产物经 ALIGN 套层，name 变 `"ALIGN"`。而 `addSpecialNormalize("MA", ...)` 经 `found_name = ind.name()` 存入 `m_special_category["MA"]`。热点循环 `ind_name = all_stk_inds[0][ii].name()` 取对齐后 name `"ALIGN"`，`m_special_category.find("ALIGN")` 永远不命中，行业中性化（以及风格/特殊标准化）全部静默跳过。

## 修复方案

### 缺陷一：O(n) 组内去均值

数学等价性：当行业归属互斥（一只股票只属一个行业）且仅对这一个分类变量做中性化时，"去全局截距的 one-hot 多元回归取残差"严格等价于"组内去均值"：

$$\min_\beta \sum_i (y_i - \sum_k X_{i,k}\beta_k)^2 \quad \text{因 } X \text{ 互斥 one-hot，可拆成各行业独立求和}$$

$$\hat{\beta}_k = \text{mean}(y_{group(k)}), \quad e_i = y_i - \text{mean}(y_{group(i)})$$

无需构造设计矩阵与 QR 分解，两趟扫描 O(n) 即可，天然兼容每日动态 NaN 掩码（算组内均值时跳过无效值），避免多线程下 Eigen 矩阵堆分配争用。

`calculate_industry_residuals(y, labels, blk_count)`：
- Pass 1 累计各组有效 y 的和与计数（跳过 NaN/Inf 与无归属股票 `label>=blk_count`）
- Pass 2 残差 = y_i - mean(y_group(i))；无归属或该组无有效样本时残差置 NaN
- NaN/Inf 标签经 `isnan/isinf` 守卫后再 `static_cast<size_t>`，避免 UB

### 缺陷二：按下标溯源原名

热点循环 `ind_name = all_stk_inds[0][ii].name()` → `ind_name = m_factorset[ii].name()`。`getValues` 产出 `result[j][i]` 严格对应 `factors[i]`（实现已核实），下标 ii 与 `m_factorset[ii]` 一一对应，无乱序风险。不触碰 ALIGN 核心层，瞬间恢复元数据路由匹配保真度。

### 实现细节

- `calculate_industry_residuals` 提取为 `industry_neutralize.h` inline 函数，供白盒单元测试直接包含调用（绕过 file-static 不可达问题，利用 ODR 豁免，无需改构建配置）
- `_buildDummyIndex` 返回类型改为 `unordered_map<string, pair<PriceList, size_t>>`（labels + blk_count），避免消费处重复调 `getBlockList`
- 删除已无调用方的单变量 `calculate_residuals(const PriceList&, const PriceList&)`（曾导致本 bug 的函数，留着是定时炸弹）
- 市值中性化（风格因子路径）不动，仍走多元 `calculate_residuals`

## 验证

### 编译

- 环境：Windows MSVC 2022 + xmake，local/dev 分支（含编译适配）合并 fix 改动编译
- 结果：`xmake -b unit-test` build ok，仅 pre-existing 的 `utils.cpp` 有符号/无符号 warning（与本 PR 无关）

### 功能验证

**白盒测试 6 用例**（`test_MF_IndustryNeutralize.cpp`，直接测 `calculate_industry_residuals` 纯函数，零外部依赖）：

| 用例 | 验证点 |
|------|--------|
| `test_industry_residuals_permutation_invariance` | 核心反例：颠倒行业编号（`{0,0,1,1}` vs `{1,1,0,0}`），残差完全一致——锁死置换不变性 |
| `test_industry_residuals_orphan_and_nan_label` | 无归属股票（label>=blk_count）与标签 NaN：残差置 NaN，不参与组内均值 |
| `test_industry_residuals_single_group_global_mean` | k=1 全市场同行业：退化为去全局均值 |
| `test_industry_residuals_group_with_invalid_y` | 同行业含 NaN：算均值跳过 NaN，残差对无效点置 NaN |
| `test_industry_residuals_all_invalid` | 全 NaN/Inf 输入：不崩溃不抛浮点异常，返回全 NaN |
| `test_industry_residuals_negative_and_oversized_label` | 负数/超大标签：守卫 `static_cast<size_t>(负数)` 的 UB，不崩溃不越界，残差置 NaN |

**E2E 路由验证**（`test_mf_industry_neutralize_routing`，依赖 `test_data/block/hybk.ini`）：

采用**动态发现策略**——遍历"行业板块"所有板块，找第一个含≥2只有效 K 线（≥10根）股票的板块作为同行业探针对（不硬编码特定股票代码，CI 数据变动自动适配；若整个分类无同行业对，REQUIRE 失败明确暴露数据不足，不静默通过）。`NORM_NOTHING` 关闭标准化，`addSpecialNormalize("MA", ..., "行业板块")` 启用行业中性化，断言两只同行业股票截面残差和 ≈ 0（反静默失效探针：若 name 路由匹配失败，输出原始 MA 值，两只不同股价的 MA 之和不会为 0 → 断言失败暴露 bug）。

> 注1：`getAllSrcFactors()` 依赖 `m_ref_dates` 已填充（由 `calculate()` 填充），测试需先调 `getDatetimeList()` 触发 calculate，否则 m_ref_dates 为空导致中性化循环跳过。这是 master 既有 API 行为，非本 PR 引入，测试中规避。
>
> 注2：测试环境用 QLBlockInfoDriver（读 ini），其 `save` 抛 "Not support"，无法用 `sm.addBlock` 注入内存 Mock Block，故采用动态发现而非 mock。

### 回归测试

完整测试套件：

```
[doctest] test cases:    696 |    696 passed | 0 failed | 0 skipped
[doctest] assertions: 196942 | 196942 passed | 0 failed |
[doctest] Status: SUCCESS!
```

基线 690 用例 + 新增 7 用例（6 白盒 + 1 E2E）= 697（含 1 个 doctest 内部用例），0 回归（196942 断言全绿）。

## 改动范围

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp` | +30/-57：新增 `calculate_industry_residuals` 调用、`_buildDummyIndex` 返回类型带 blk_count、热点循环 name 路由修复、删除单变量 calculate_residuals |
| `hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.h` | +6/-0：`_buildDummyIndex` 声明返回类型变更 |
| `hikyuu_cpp/hikyuu/trade_sys/multifactor/industry_neutralize.h` | +80：新增 inline 纯函数（含 NaN/Inf/负数/超大标签 UB 守卫，供 cpp 与测试共用） |
| `hikyuu_cpp/unit_test/hikyuu/trade_sys/multifactor/test_MF_IndustryNeutralize.cpp` | +201：6 白盒 + 1 E2E 测试（动态发现） |

合计 4 文件，+315/-57。

## 性能影响

| 维度 | 原实现 | 修复后 |
|------|--------|--------|
| 算法复杂度 | O(n) 单变量回归（但数学错误） | O(n) 组内去均值（数学正确） |
| QR 分解 | 无 | 无（等价性证明免除了 QR 需求） |
| heap 分配 | 单变量版无 Eigen 矩阵 | `std::vector<double> sums/counts`（blk_count<100，栈上小量分配） |

性能不退化：同样是 O(n)，新实现纯标量运算无 QR 分解。`sums/counts` 的 `std::vector` 构造在热点循环内有微量堆分配，但 blk_count<100 量级无实证瓶颈（完整测试套件 8.5 秒），保持纯函数简洁性优先于过早优化。已知优化项：未来若 profiler 显示该处为热点，可改为调用方传入预分配缓冲，但会破坏纯函数签名与白盒测试简洁性。

## 已知局限与后续工作

本 PR 聚焦修复行业中性化的数学错误（整数编码单变量回归）与路由静默失效（ALIGN 改名），属于 bug fix。以下三项是审查中提出的更优方案，统计学/架构上有价值，但超出本 PR 范围，列为后续 issue 单独处理：

### 1. 序列中性化 vs 联合多元回归（Frisch-Waugh-Lovell）

**现状**：hikyuu 的中性化架构是**序列正交化**——热点循环里先做行业中性化（`calculate_industry_residuals`），再对残差做市值中性化（多元 `calculate_residuals`），分两步独立回归。这是 master 既有设计，本 PR 维持未改。

**局限**：根据 Frisch-Waugh-Lovell 定理，除非行业哑变量与市值因子在截面上严格正交（协方差为 0），否则序列中性化残差 ≠ 联合多元回归残差。A 股市值与行业高度共线（如银行股普遍市值大），序列处理会产生残差偏误。

**后续方向**：构建联合设计矩阵 `X = [OneHot(Industry), MarketCap]` 一次性多元回归求残差。这需要重构整个中性化引擎（行业与风格因子统一进多元回归路径，废弃独立的 O(n) 行业函数），是独立的设计议题，非本 bug fix 范围。

### 2. ALIGN 算子的 name 继承机制

**现状**：本 PR 用 `m_factorset[ii].name()` 按下标溯源原名，绕过 ALIGN 改名导致的路由失配。这是最小侵入的修复，只打通行业中性化的触发路径。

**局限**：ALIGN 改名是更底层的元数据污染——`ALIGN` 作为对齐算子覆盖了原始因子身份标识 `"ALIGN"`。本 PR 的下标溯源只修了 `MultiFactorBase` 热点循环这一个消费点，框架中其他依赖对齐后数据 name 的下游模块（日志、归因、可视化）仍会读到无意义的 `"ALIGN"`。

**后续方向**：在 `ALIGN` 算子内部保留或透传源数据标识，从根源修复 name 继承。这影响全框架所有 ALIGN 下游，需独立评估风险。

### 3. 热点循环堆分配

**现状**：`calculate_industry_residuals` 内 `std::vector<double> sums/counts` 在按日多线程热点循环中构造，blk_count<100 量级。完整测试套件 8.5 秒无可见瓶颈。

**局限**：多线程并行回测下，vector 动态内存申请的 malloc/free 争用与缓存未命中理论上会被放大。

**后续方向**：待 profiler 显示该处为热点后，可改用 `std::array<MaxBlks>` 栈分配或 `thread_local` 预分配缓冲。当前无实证瓶颈，避免过早优化破坏纯函数简洁性。

