### PR TITLE
fix(indicator): ISpearman tie-handling 用 Pearson-on-ranks 替换简化公式

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/imp/ISpearman.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ISpearman.cpp
@@ -84,48 +84,6 @@ void ISpearman::_calculate(const Indicator &ind) {
     }
 
     _increment_calculate(ind, m_discard);
-
-#if 0
-    auto levela = std::make_unique<value_t[]>(n);
-    auto levelb = std::make_unique<value_t[]>(n);
-    auto *ptra = levela.get();
-    auto *ptrb = levelb.get();
-
-    // 不处理 n 不足的情况，防止只需要计算全部序列时，过于耗时
-    double back = std::pow(n, 3) - n;
-    vector<IndicatorImp::value_t> tmpa;
-    vector<IndicatorImp::value_t> tmpb;
-    tmpa.reserve(n);
-    tmpa.reserve(n);
-
-    auto *dst = this->data();
-    auto const *a = ind.data() + m_discard + 1 - n;
-    auto const *b = ref.data() + m_discard + 1 - n;
-    for (size_t i = m_discard; i < total; ++i) {
-        tmpa.clear();
-        tmpb.clear();
-        for (int j = 0; j < n; j++) {
-            if (!std::isnan(a[j]) && !std::isnan(b[j])) {
-                tmpa.push_back(a[j]);
-                tmpb.push_back(b[j]);
-            }
-        }
-        int act_count = tmpa.size();
-        if (act_count < 2) {
-            continue;
-        }
-        spearmanLevel(tmpa.data(), ptra, act_count);
-        spearmanLevel(tmpb.data(), ptrb, act_count);
-        value_t sum = 0.0;
-        for (int j = 0; j < act_count; j++) {
-            sum += std::pow(ptra[j] - ptrb[j], 2);
-        }
-        dst[i] = act_count == n ? 1.0 - 6.0 * sum / back
-                                : 1.0 - 6.0 * sum / (std::pow(act_count, 3) - act_count);
-        a++;
-        b++;
-    }
-#endif
 }
 
 bool ISpearman::supportIncrementCalculate() const {
@@ -141,7 +99,6 @@ void ISpearman::_increment_calculate(const Indicator &ind, size_t start_pos) {
     Indicator ref = prepare(ind);
 
     int n = getParam<int>("n");
-    double back = std::pow(n, 3) - n;
     auto *dst = this->data();
     auto const *srca = ind.data() + 1 - n;
     auto const *srcb = ref.data() + 1 - n;
@@ -172,12 +129,29 @@ void ISpearman::_increment_calculate(const Indicator &ind, size_t start_pos) {
 
           spearmanLevel(tmpa.data(), ptra, act_count);
           spearmanLevel(tmpb.data(), ptrb, act_count);
-          value_t sum = 0.0;
+          // 对 rank 直接计算 Pearson 相关系数（tie-safe）。
+          // 关键性质: average-rank 不改变秩的总和, 故 rank 均值恒为先验常数
+          // (act_count+1)/2, 无需遍历估计, 消除大数相减的 catastrophic cancellation。
+          double mean_rank = (act_count + 1) / 2.0;
+          double var_r = 0.0, var_s = 0.0, cov = 0.0;
           for (int j = 0; j < act_count; j++) {
-              sum += std::pow(ptra[j] - ptrb[j], 2);
+              double dev_r = ptra[j] - mean_rank;
+              double dev_s = ptrb[j] - mean_rank;
+              var_r += dev_r * dev_r;
+              var_s += dev_s * dev_s;
+              cov += dev_r * dev_s;
           }
-          dst[i] = act_count == n ? 1.0 - 6.0 * sum / back
-                                  : 1.0 - 6.0 * sum / (std::pow(act_count, 3) - act_count);
+          // 零方差(因子或收益率在截面上全等)时返回 0.0:
+          // 语义为"无区分度即无预测力"。不返回 NaN, 因下游 MA 指标对 NaN
+          // 为"一 NaN 全 NaN"传染(且首窗口含 NaN 会静默输出偏低错误值),
+          // 加权合成无 NaN 守卫, NaN 会扩散污染约 ic_rolling_n 天的权重。
+          if (var_r == 0.0 || var_s == 0.0) {
+              dst[i] = 0.0;
+          } else {
+              double rho = cov / std::sqrt(var_r * var_s);
+              // 钳位处理浮点误差引发的越界
+              dst[i] = std::max(-1.0, std::min(1.0, rho));
+          }
       },
       100);
 }

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_SPEARMAN.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_SPEARMAN.cpp
@@ -141,7 +141,7 @@ TEST_CASE("test_SPEARMAN") {
     CHECK_THROWS_AS(SPEARMAN(x, y, 1), std::exception);
 
     /** @arg 正常情况 n */
-    PriceList expect{Null<price_t>(), 1., 1., 0.95, 0.875};
+    PriceList expect{Null<price_t>(), 1., 1., 0.95, 0.872082};
     result = SPEARMAN(x, y, a.size());
     CHECK_EQ(result.name(), "SPEARMAN");
     CHECK_EQ(result.discard(), 4);
@@ -150,7 +150,7 @@ TEST_CASE("test_SPEARMAN") {
         CHECK_EQ(result[i], doctest::Approx(expect[i]));
     }
 
-    expect = {Null<price_t>(), Null<price_t>(), 1., 0.875, 1.};
+    expect = {Null<price_t>(), Null<price_t>(), 1., 0.866025, 1.};
     result = SPEARMAN(x, y, 3);
     CHECK_EQ(result.name(), "SPEARMAN");
     CHECK_EQ(result.discard(), 2);
@@ -173,6 +173,45 @@ TEST_CASE("test_SPEARMAN") {
     CHECK_EQ(result[5], doctest::Approx(-1.));
     CHECK_EQ(result[6], doctest::Approx(-1.));
     CHECK_UNARY(std::isnan(result[7]));
+}
+
+/** @par 检测点 */
+TEST_CASE("test_SPEARMAN_with_ties") {
+    // 回归 tie-handling: 当输入存在相同值(average-rank)时, 简化公式
+    // 1 - 6*sum_d2/(n^3-n) 不再精确, 必须用 Pearson-on-ranks 计算。
+    // 下列期望值由 tie 修正公式独立推导, 不依赖本实现:
+    //   rho = [n(n^2-1)/6 - T_x - T_y - sum_d2]
+    //         / [2*sqrt((n(n^2-1)/12 - T_x)(n(n^2-1)/12 - T_y))]
+
+    /** @arg 双向 tie: a 与 b 均含重复值 (T_x = T_y = 1.0)
+     *  a={3,3,5,7,7} -> ranks {1.5,1.5,3,4.5,4.5}
+     *  b={10,8,8,6,10} -> ranks {4.5,2.5,2.5,1,4.5}
+     *  buggy 简化公式给出 -0.125, 正确值 -0.25 */
+    PriceList a{3., 3., 5., 7., 7.};
+    PriceList b{10., 8., 8., 6., 10.};
+    Indicator x = PRICELIST(a);
+    Indicator y = PRICELIST(b);
+    Indicator result = SPEARMAN(x, y, a.size());
+    CHECK_EQ(result.discard(), 4);
+    CHECK_EQ(result[4], doctest::Approx(-0.25));
+
+    /** @arg 零方差退化: a 全相同 (rank 全为 3), 因子无区分度, 应返回 0.0
+     *  buggy 简化公式给出 0.5 (把"无区分度"误判为正相关) */
+    PriceList za{5., 5., 5., 5., 5.};
+    PriceList zb{1., 2., 3., 4., 5.};
+    result = SPEARMAN(PRICELIST(za), PRICELIST(zb), za.size());
+    CHECK_EQ(result.discard(), 4);
+    CHECK_EQ(result[4], doctest::Approx(0.0));
+
+    /** @arg 双向 tie + NaN 过滤 (act_count < n): 验证去除 act_count==n 分支后
+     *  仅对有效对计算仍正确。窗口 n=7, 有效对 4 个:
+     *  (3,10),(5,8),(7,6),(7,10) -> ranks a{1,2,3.5,3.5} b{3.5,2,1,3.5}
+     *  正确值 -0.388889 */
+    price_t null_value = Null<price_t>();
+    PriceList na{3., 3., null_value, 5., 7., 7., null_value};
+    PriceList nb{10., null_value, 8., 8., 6., 10., null_value};
+    result = SPEARMAN(PRICELIST(na), PRICELIST(nb), 7);
+    CHECK_EQ(result[6], doctest::Approx(-0.388889));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## 问题概述

`ISpearman` 在存在相同值（ties）时计算的 Spearman 相关系数不精确。`spearmanLevel` 已正确分配 average-rank，但 `_increment_calculate` 随后用了仅在无 tie 时成立的简化公式 1 − 6Σd²/(n³−n)。A 股截面中 ties 极常见（涨跌停、停牌收益=0、离散型因子），导致所有默认 `spearman=True` 的下游——`IC`、`ICIR`、`MF_ICWeight`、`MF_ICIRWeight`、`SE_MultiFactor`——在含 tie 的截面上产生系统性偏差，且零方差时误判为"完美正相关"。

## 根因分析

Spearman 的标准定义是对 rank 向量计算 Pearson 相关系数：

$$\rho = \frac{\sum_j (R_j - \bar{R})(S_j - \bar{S})}{\sqrt{\sum_j (R_j - \bar{R})^2 \cdot \sum_j (S_j - \bar{S})^2}}$$

当两个 rank 向量都是 $\{1, 2, ..., n\}$ 的排列（即无 tie）时，恒等式 $\sum(R_j - \bar{R})^2 = \frac{n(n^2-1)}{12}$ 成立，上式可化简为教科书公式：

$$\rho = 1 - \frac{6\sum d_j^2}{n^3 - n}$$

当存在 tie，`spearmanLevel` 正确地将相等值赋为 average-rank（例如位置 4、5 的两个相等值都赋 4.5）。但 average-rank 不再是 $\{1,...,n\}$ 的排列，上述恒等式失效，简化公式失去推导前提。

```cpp
// ISpearman.cpp _increment_calculate (修复前)
spearmanLevel(tmpa.data(), ptra, act_count);  // 正确分配 average-rank
spearmanLevel(tmpb.data(), ptrb, act_count);  // 正确分配 average-rank
value_t sum = 0.0;
for (int j = 0; j < act_count; j++) {
    sum += std::pow(ptra[j] - ptrb[j], 2);
}
// 缺陷：简化公式仅在无 tie 时精确，average-rank 使其失效
dst[i] = act_count == n ? 1.0 - 6.0 * sum / back
                        : 1.0 - 6.0 * sum / (std::pow(act_count, 3) - act_count);
```

数值验证（现有测试数据 $a=\{3,8,4,7,2\}$ vs $b=\{5,10,8,10,6\}$，b 含 tie）：

| 方法 | 结果 |
|------|------|
| 简化公式（修复前） | 0.875 |
| Pearson-on-ranks（修复后） | 0.872082 |
| tie 修正公式（独立基准） | 0.872082 |

两种独立正确方法交叉验证一致，差 0.0029。现有测试期望值 0.875 是照 buggy 实现写死的，非独立基准。

**零方差附加错误**：因子值在截面上全相同时，rank 全等，Σd² = 0，简化公式给出 1.0——把"无区分度"误判为"完美正相关"。

## 修复方案

### 核心算法：先验均值 Pearson-on-ranks

对 rank 直接计算 Pearson 相关系数（tie-safe 的标准做法，与 `scipy.stats.spearmanr` 一致）。

**关键优化**：average-rank 把长度 $t$ 的 tie 组的连续整数秩替换为均值，秩和不变。故 rank 均值恒为先验常数：

$$\sum_{j=1}^{m} R_j = \frac{m(m+1)}{2}, \quad \bar{R} = \frac{m+1}{2}$$

直接用此精确无误差的常数作均值，单遍中心化即可，无需遍历估计样本均值，也消除大数相减的 catastrophic cancellation。

```cpp
// ISpearman.cpp _increment_calculate (修复后)
spearmanLevel(tmpa.data(), ptra, act_count);
spearmanLevel(tmpb.data(), ptrb, act_count);
// rank 均值恒为先验常数 (act_count+1)/2，无论是否存在 tie 均成立
double mean_rank = (act_count + 1) / 2.0;
double var_r = 0.0, var_s = 0.0, cov = 0.0;
for (int j = 0; j < act_count; j++) {
    double dev_r = ptra[j] - mean_rank;
    double dev_s = ptrb[j] - mean_rank;
    var_r += dev_r * dev_r;
    var_s += dev_s * dev_s;
    cov += dev_r * dev_s;
}
if (var_r == 0.0 || var_s == 0.0) {
    dst[i] = 0.0;  // 零方差退化：无区分度=无预测力
} else {
    double rho = cov / std::sqrt(var_r * var_s);
    dst[i] = std::max(-1.0, std::min(1.0, rho));  // 钳位浮点越界
}
```

### 关键设计决策

1. **先验均值而非样本均值**：rank 均值 `(act_count+1)/2` 是精确无误差的常数。直接用它中心化，规避大数相减的 cancellation，省去样本均值遍历。**注意：均值是常数但方差不是**——ties 使实际方差严格小于理论值 $\frac{m(m^2-1)}{12}$，必须显式累加真实方差，禁用理论值。

2. **double 累加器**：累加器显式声明 `double`，`mean_rank` 为 double，`ptra[j] - mean_rank` 自动提升为 double，无论 `value_t` 是 float 还是 double 都在 double 精度下累加。

3. **零方差退化返回 0.0 而非 NaN**：零方差 = 因子无区分度 = 无预测力，返回 0.0。不返回 NaN 是因为下游 `MA` 指标对 NaN 为"一 NaN 全 NaN"传染（`IMa.cpp` 滚动段任一 NaN 则该窗口输出 NaN，首窗口含 NaN 还会静默输出偏低错误值），而 `ICMultiFactor`/`ICIRMultiFactor` 的加权合成无 NaN 守卫，NaN 会扩散污染约 `ic_rolling_n`（默认 120）天的权重。0.0 局部温和、不扩散。

4. **删除 `act_count == n` 分支**：旧分支因 `back = n³-n` 为全窗口预算而设，NaN 过滤致 `act_count < n` 时需重算。改用 Pearson 后有效数自然融入协方差/方差，分支自动消解。

5. **删除 `#if 0` 死代码块**：含同样的缺陷公式，一并清理避免后续误启用。

## 验证

### 编译

Windows 11 + MSVC + VS2022 + xmake，`build ok`，仅 2 个既有的 `utils.cpp` 符号/无符号 warning（与本次改动无关）。

### 功能验证

新增 `test_SPEARMAN_with_ties`，期望值由 tie 修正公式独立推导（不依赖本实现）：

$$\rho = \frac{\frac{m(m^2-1)}{6} - T_x - T_y - \sum d_j^2}{2\sqrt{\left(\frac{m(m^2-1)}{12} - T_x\right)\left(\frac{m(m^2-1)}{12} - T_y\right)}}, \quad T = \sum_{\text{groups}} \frac{t^3 - t}{12}$$

| 用例 | 数据 | 修复前 | 修复后 | 验证点 |
|------|------|--------|--------|--------|
| 双向 tie | $a=\{3,3,5,7,7\}$ $b=\{10,8,8,6,10\}$ | -0.125 | -0.25 | $T_x=T_y=1.0$ |
| 零方差退化 | $a=\{5,5,5,5,5\}$ $b=\{1,2,3,4,5\}$ | 0.5 | 0.0 | 因子全相同 |
| 双向 tie + NaN | $a=\{3,3,\text{nan},5,7,7,\text{nan}\}$ $b=\{10,\text{nan},8,8,6,10,\text{nan}\}$ | — | -0.388889 | `act_count=4 < n=7` |

同时更新现有 `test_SPEARMAN` 两个受 tie 影响的期望值：0.875 → 0.872082（n=5 全窗口）、0.875 → 0.866025（n=3 滚动）。现有 NaN 测试用例（`result[5]=result[6]=-1.0`）在新公式下经手算验证仍成立。

### 回归测试

```
[doctest] test cases:    691 |    691 passed | 0 failed | 0 skipped
[doctest] assertions: 196915 | 196915 passed | 0 failed |
[doctest] Status: SUCCESS!
```

691 用例全绿（基线 690 + 新增 1），0 回归。

## 改动范围

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/imp/ISpearman.cpp` | +13/-49：替换公式 + 删 `#if 0` 死代码 + 删 `back` 变量 |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_SPEARMAN.cpp` | +43/-2：更新 2 期望值 + 新增 `test_SPEARMAN_with_ties`（3 子用例） |

合计 2 文件，+62/-49。不改任何 API 签名/返回类型，外部无感知。

## 性能影响

聚合步骤保持 O(act_count) 单遍遍历，与修复前同阶。常数项略增（3 个累加器 vs 1 个），但被前置 `spearmanLevel` 的 $O(m\log m)$ 排序绝对主导，对总吞吐无可见影响。无额外内存。

## 已知局限与后续工作

### 下游 MA 指标对 NaN 的处理存在技术债

**现状**：`IMa.cpp` 滚动段任一 NaN 则该窗口输出 NaN（"一 NaN 全 NaN"）；首窗口含 NaN 时分母恒为 n 而 sum 跳过 NaN，静默输出偏低错误值；NaN 位置 sum 不扣减导致后续窗口持续偏差。`IStdev.cpp` 则正确跳过 NaN。这是 master 既有设计，本 PR 维持未改。

**局限**：本 PR 选择零方差退化返回 0.0 而非 NaN，正是为绕过 MA 的传染特性。但若其他指标向 IC 序列注入 NaN（如停牌导致收益率缺失），MA 的"一 NaN 全 NaN"仍会污染滚动 IC/ICIR。

**后续方向**：独立 issue 修复 `IMa.cpp` 的 NaN 状态管理（首窗口分母应用有效值个数；滚动段 NaN 位置应重置 sum 而非跳过），并统一 MA/STDEV 对 NaN 的处理口径。零方差退化是否随之改回 NaN 以符合统计语义，待该 issue 一并评估。
