### PR TITLE
fix(IMa/IStdev): MA/STDEV NaN 语义统一为 Welford valid mean/std

### DIFF
--- a/hikyuu/draw/drawplot/echarts_draw.py
+++ b/hikyuu/draw/drawplot/echarts_draw.py
@@ -551,7 +551,7 @@ def sys_performance(sys, ref_stk=None):
 
     # 计算 sharp
     bond = ZHBOND10(ref_dates)
-    sigma = STDEV(ROCP(funds), len(ref_dates))
+    sigma = STDEV(ROCP(funds), 0)  # n=0: 全期样本标准差（expand-all）
     sigma = 15.874507866387544 * sigma[-1]  # 15.874 = sqrt(252)
     sharp = (per['帐户平均年收益率%'] - bond[-1]) * 0.01 / sigma if sigma != 0.0 else 0.0
 

--- a/hikyuu/draw/drawplot/matplotlib_draw.py
+++ b/hikyuu/draw/drawplot/matplotlib_draw.py
@@ -893,7 +893,7 @@ def tm_performance(tm: TradeManager, query: Query, ref_stk: Stock = None, ext: b
 
     # 计算 sharp
     bond = ZHBOND10(ref_dates)
-    sigma = STDEV(ROCP(funds), len(ref_dates))
+    sigma = STDEV(ROCP(funds), 0)  # n=0: 全期样本标准差（expand-all）
     sigma = 15.874507866387544 * sigma[-1]  # 15.874 = sqrt(252)
     sharp = (per['帐户平均年收益率%'] - bond[-1]) * 0.01 / sigma if sigma != 0.0 else 0.0
 

--- a/hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp
@@ -59,20 +59,40 @@ void IMa::_calculate(const Indicator& indicator) {
         return;
     }
 
+    // Welford 滚动均值：状态 (valid_count, mean)，O(1) 出入队。
+    // 与 IStdev 共用相同的 valid_count 增减逻辑，保证 MA/STDEV 基于完全一致的样本集。
     size_t startPos = indicator.discard();
-    price_t sum = 0.0;
-    for (size_t i = startPos; i <= m_discard; ++i) {
-        if (!std::isnan(src[i])) {
-            sum += src[i];
+    size_t valid_count = 0;
+    price_t mean = 0.0;
+    for (size_t i = startPos; i < total; ++i) {
+        // 移除 leaving（窗口已满时）
+        if (i >= static_cast<size_t>(startPos) + static_cast<size_t>(n)) {
+            price_t leaving = src[i - n];
+            if (!std::isnan(leaving)) {
+                if (valid_count > 1) {
+                    price_t delta = leaving - mean;
+                    mean -= delta / (valid_count - 1);
+                } else {
+                    // valid_count == 1，移除后窗口归零
+                    mean = 0.0;
+                }
+                valid_count--;
+            }
         }
-    }
-
-    dst[m_discard] = sum / n;
-
-    for (size_t i = m_discard + 1; i < total; ++i) {
-        if (!std::isnan(src[i]) && !std::isnan(src[i - n])) {
-            sum = src[i] + sum - src[i - n];
-            dst[i] = sum / n;
+        // 加入 entering
+        price_t entering = src[i];
+        if (!std::isnan(entering)) {
+            valid_count++;
+            if (valid_count == 1) {
+                mean = entering;
+            } else {
+                price_t delta = entering - mean;
+                mean += delta / valid_count;
+            }
+        }
+        // 窗口未满或无有效值时不写输出（缓冲区已是 NaN）
+        if (i >= m_discard && valid_count > 0) {
+            dst[i] = mean;
         }
     }
 }
@@ -93,21 +113,36 @@ void IMa::_increment_calculate(const Indicator& indicator, size_t startPos) {
     auto* dst = this->data();
 
     int n = getParam<int>("n");
-    HKU_ASSERT(startPos + 1 >= n);
+    HKU_ASSERT(startPos + 1 >= (size_t)n);
+    // 从窗口起点 startPos+1-n 单趟重建 Welford 均值状态，再滚动至 total
     size_t start = startPos + 1 - n;
-    value_t sum = 0.0;
-    for (size_t i = start; i <= startPos; ++i) {
-        if (!std::isnan(src[i])) {
-            sum += src[i];
+    size_t valid_count = 0;
+    price_t mean = 0.0;
+    for (size_t i = start; i < total; ++i) {
+        if (i > startPos) {
+            price_t leaving = src[i - n];
+            if (!std::isnan(leaving)) {
+                if (valid_count > 1) {
+                    price_t delta = leaving - mean;
+                    mean -= delta / (valid_count - 1);
+                } else {
+                    mean = 0.0;
+                }
+                valid_count--;
+            }
         }
-    }
-
-    dst[startPos] = sum / n;
-
-    for (size_t i = startPos + 1; i < total; ++i) {
-        if (!std::isnan(src[i]) && !std::isnan(src[i - n])) {
-            sum = src[i] + sum - src[i - n];
-            dst[i] = sum / n;
+        price_t entering = src[i];
+        if (!std::isnan(entering)) {
+            valid_count++;
+            if (valid_count == 1) {
+                mean = entering;
+            } else {
+                price_t delta = entering - mean;
+                mean += delta / valid_count;
+            }
+        }
+        if (i >= startPos && valid_count > 0) {
+            dst[i] = mean;
         }
     }
 }
@@ -117,11 +152,23 @@ void IMa::_dyn_run_one_step(const Indicator& ind, size_t curPos, size_t step) {
     if (curPos + 1 < ind.discard() + step) {
         return;
     }
-    price_t sum = 0.0;
+    // 单趟 Welford 均值（动态窗口左边界跳变，不用 remove）
+    size_t valid_count = 0;
+    price_t mean = 0.0;
     for (size_t i = start; i <= curPos; i++) {
-        sum += ind[i];
+        if (!std::isnan(ind[i])) {
+            valid_count++;
+            if (valid_count == 1) {
+                mean = ind[i];
+            } else {
+                price_t delta = ind[i] - mean;
+                mean += delta / valid_count;
+            }
+        }
     }
-    _set(sum / (curPos - start + 1), curPos);
+    if (valid_count > 0) {
+        _set(mean, curPos);
+    }
 }
 
 Indicator HKU_API MA(int n) {

--- a/hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp
@@ -39,10 +39,12 @@ void IMa::_calculate(const Indicator& indicator) {
         }
 
         price_t sum = 0.0;
+        size_t valid_count = 0;
         for (size_t i = m_discard; i < total; i++) {
             if (!std::isnan(src[i])) {
                 sum += src[i];
-                dst[i] = sum / (i - m_discard + 1);
+                valid_count++;
+                dst[i] = sum / valid_count;
             }
         }
         return;

--- a/hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp
@@ -148,10 +148,10 @@ void IMa::_increment_calculate(const Indicator& indicator, size_t startPos) {
 }
 
 void IMa::_dyn_run_one_step(const Indicator& ind, size_t curPos, size_t step) {
-    size_t start = _get_step_start(curPos, step, ind.discard());
     if (curPos + 1 < ind.discard() + step) {
         return;
     }
+    size_t start = _get_step_start(curPos, step, ind.discard());
     // 单趟 Welford 均值（动态窗口左边界跳变，不用 remove）
     size_t valid_count = 0;
     price_t mean = 0.0;

--- a/hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp
@@ -214,6 +214,9 @@ void IStdev::_increment_calculate(const Indicator& data, size_t start_pos) {
 }
 
 void IStdev::_dyn_run_one_step(const Indicator& ind, size_t curPos, size_t step) {
+    if (curPos + 1 < ind.discard() + step) {
+        return;
+    }
     size_t start = _get_step_start(curPos, step, ind.discard());
     // 单趟 Welford（动态窗口左边界跳变，不用 remove，无重算需求）
     size_t valid_count = 0;

--- a/hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp
@@ -57,7 +57,7 @@ void IStdev::_calculate(const Indicator& data) {
                 }
             }
             if (valid_count > 1) {
-                dst[i] = std::sqrt(M2 / (valid_count - 1));
+                dst[i] = std::sqrt(std::max(0.0, M2 / (valid_count - 1)));
             }
         }
         return;
@@ -133,7 +133,7 @@ void IStdev::_calculate(const Indicator& data) {
         }
         // 窗口未满或有效值不足时不写输出（缓冲区已是 NaN）
         if (i >= m_discard && valid_count > 1) {
-            dst[i] = std::sqrt(M2 / (valid_count - 1));
+            dst[i] = std::sqrt(std::max(0.0, M2 / (valid_count - 1)));
         }
     }
 }
@@ -208,7 +208,7 @@ void IStdev::_increment_calculate(const Indicator& data, size_t start_pos) {
             }
         }
         if (i >= start_pos && valid_count > 1) {
-            dst[i] = std::sqrt(M2 / (valid_count - 1));
+            dst[i] = std::sqrt(std::max(0.0, M2 / (valid_count - 1)));
         }
     }
 }
@@ -233,7 +233,7 @@ void IStdev::_dyn_run_one_step(const Indicator& ind, size_t curPos, size_t step)
         }
     }
     if (valid_count > 1) {
-        _set(std::sqrt(M2 / (valid_count - 1)), curPos);
+        _set(std::sqrt(std::max(0.0, M2 / (valid_count - 1))), curPos);
     }
 }
 

--- a/hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp
@@ -29,73 +29,112 @@ void IStdev::_checkParam(const string& name) const {
 
 void IStdev::_calculate(const Indicator& data) {
     size_t total = data.size();
-    m_discard = data.discard();
+    int n = getParam<int>("n");
+
+    auto const* src = data.data();
+    auto* dst = this->data();
+
+    // n == 0：全量累计标准差（expand-all 语义，每个位置输出到当前位置的累计 std）
+    if (0 == n) {
+        m_discard = data.discard();
+        if (m_discard >= total) {
+            m_discard = total;
+            return;
+        }
+        size_t valid_count = 0;
+        price_t mean = 0.0;
+        price_t M2 = 0.0;
+        for (size_t i = m_discard; i < total; ++i) {
+            if (!std::isnan(src[i])) {
+                valid_count++;
+                if (valid_count == 1) {
+                    mean = src[i];
+                    M2 = 0.0;
+                } else {
+                    price_t delta = src[i] - mean;
+                    mean += delta / valid_count;
+                    M2 += delta * (src[i] - mean);
+                }
+            }
+            if (valid_count > 1) {
+                dst[i] = std::sqrt(M2 / (valid_count - 1));
+            }
+        }
+        return;
+    }
+
+    // n > 0：滚动窗口 Welford 方差，状态 (valid_count, mean, M2)，O(1) 出入队。
+    // 与 IMa 共用相同的 valid_count/mean 更新逻辑，保证 MA/STDEV 基于一致样本集。
+    // 离群值离开窗口时 M2 可能因灾难性相消变为负值或丢失低位精度，
+    // 此时触发 O(k) 单趟重算（k=窗口长度 n）重建精确状态。
+    m_discard = data.discard() + n - 1;
     if (m_discard >= total) {
         m_discard = total;
         return;
     }
 
-    int n = getParam<int>("n");
-    if (0 == n) {
-        n = total;
-    }
-
-    auto const* src = data.data();
-    auto* dst = this->data();
-
-    vector<price_t> pow_buf(data.size());
-    price_t ex = 0.0, ex2 = 0.0;
-    size_t num = 0;
-    size_t start_pos = m_discard;
-    size_t first_end = start_pos + n >= total ? total : start_pos + n;
-    price_t k = src[start_pos];
-    for (size_t i = start_pos; i < first_end; i++) {
-        if (!std::isnan(src[i])) {
-            num++;
-            price_t d = src[i] - k;
-            ex += d;
-            price_t d_pow = std::pow(d, 2);
-            pow_buf[i] = d_pow;
-            ex2 += d_pow;
-            // dst[i] = num == 1 ? 0. : std::sqrt((ex2 - std::pow(ex, 2) / num) / (num - 1));
-            if (num > 1) {
-                dst[i] = std::sqrt((ex2 - std::pow(ex, 2) / num) / (num - 1));
-            }
-        }
-    }
-
-    for (size_t i = first_end; i < total; i++) {
-        if (!std::isnan(src[i])) {
-            size_t j = i - n;
-            for (; j < i; j++) {
-                if (!std::isnan(src[j])) {
-                    break;
+    size_t startPos = data.discard();
+    size_t valid_count = 0;
+    price_t mean = 0.0;
+    price_t M2 = 0.0;
+    for (size_t i = startPos; i < total; ++i) {
+        // 移除 leaving
+        if (i >= static_cast<size_t>(startPos) + static_cast<size_t>(n)) {
+            price_t leaving = src[i - n];
+            if (!std::isnan(leaving)) {
+                if (valid_count > 1) {
+                    price_t old_M2 = M2;
+                    price_t delta = leaving - mean;
+                    mean -= delta / (valid_count - 1);
+                    M2 -= delta * (leaving - mean);
+                    valid_count--;
+                    // 灾难性相消检测：M2 变负或较 remove 前缩减 10^9 倍（float64 有效位坍塌）时重算
+                    if (M2 < 0.0 || M2 < 1e-9 * old_M2) {
+                        // O(n) 单趟 Welford 重算 [i-n+1, i-1]（已移除 leaving，未加入 entering）
+                        size_t vc_r = 0;
+                        price_t mean_r = 0.0, M2_r = 0.0;
+                        size_t lo = i - static_cast<size_t>(n) + 1;
+                        for (size_t j = lo; j < i; ++j) {
+                            if (!std::isnan(src[j])) {
+                                vc_r++;
+                                if (vc_r == 1) {
+                                    mean_r = src[j];
+                                } else {
+                                    price_t d = src[j] - mean_r;
+                                    mean_r += d / vc_r;
+                                    M2_r += d * (src[j] - mean_r);
+                                }
+                            }
+                        }
+                        valid_count = vc_r;
+                        mean = mean_r;
+                        M2 = M2_r;
+                    }
+                } else {
+                    // valid_count == 1，移除后窗口归零
+                    mean = 0.0;
+                    M2 = 0.0;
+                    valid_count = 0;
                 }
             }
-            if (j == i) {
-                continue;
-            }
-            // ex -= src[i - n] - k;
-            // ex2 -= pow_buf[i - n];
-            ex -= src[j] - k;
-            ex2 -= pow_buf[j];
-            price_t d = src[i] - k;
-            ex += d;
-            price_t d_pow = std::pow(d, 2);
-            pow_buf[i] = d_pow;
-            ex2 += d_pow;
-            num = i - j;
-            if (num != 1) {
-                dst[i] = std::sqrt((ex2 - std::pow(ex, 2) / num) / (num - 1));
-            }
-            // dst[i] = std::sqrt((ex2 - std::pow(ex, 2) / n) / (n - 1));
         }
-    }
-
-    // 排除第一位的0值
-    if (m_discard < total) {
-        dst[0] = Null<value_t>();
-        m_discard += 1;
+        // 加入 entering
+        price_t entering = src[i];
+        if (!std::isnan(entering)) {
+            valid_count++;
+            if (valid_count == 1) {
+                mean = entering;
+                M2 = 0.0;
+            } else {
+                price_t delta = entering - mean;
+                mean += delta / valid_count;
+                M2 += delta * (entering - mean);
+            }
+        }
+        // 窗口未满或有效值不足时不写输出（缓冲区已是 NaN）
+        if (i >= m_discard && valid_count > 1) {
+            dst[i] = std::sqrt(M2 / (valid_count - 1));
+        }
     }
 }
 
@@ -112,60 +151,90 @@ void IStdev::_increment_calculate(const Indicator& data, size_t start_pos) {
     int n = getParam<int>("n");
     auto const* src = data.data();
     auto* dst = this->data();
+    HKU_ASSERT(start_pos + 1 >= (size_t)n);
 
-    vector<price_t> pow_buf(data.size() + n - start_pos);
-    price_t ex = 0.0, ex2 = 0.0;
-    size_t num = 0;
-    price_t k = src[start_pos - n];
-    for (size_t i = start_pos - n; i < start_pos; i++) {
-        if (!std::isnan(src[i])) {
-            num++;
-            price_t d = src[i] - k;
-            ex += d;
-            price_t d_pow = std::pow(d, 2);
-            pow_buf[i + n - start_pos] = d_pow;
-            ex2 += d_pow;
-        }
-    }
-
-    for (size_t i = start_pos; i < total; i++) {
-        if (!std::isnan(src[i])) {
-            size_t j = i - n;
-            for (; j < i; j++) {
-                if (!std::isnan(src[j])) {
-                    break;
+    // 从窗口起点 start_pos+1-n 单趟重建 Welford 状态，再滚动至 total
+    size_t start = start_pos + 1 - n;
+    size_t valid_count = 0;
+    price_t mean = 0.0;
+    price_t M2 = 0.0;
+    for (size_t i = start; i < total; ++i) {
+        if (i > start_pos) {
+            price_t leaving = src[i - n];
+            if (!std::isnan(leaving)) {
+                if (valid_count > 1) {
+                    price_t old_M2 = M2;
+                    price_t delta = leaving - mean;
+                    mean -= delta / (valid_count - 1);
+                    M2 -= delta * (leaving - mean);
+                    valid_count--;
+                    if (M2 < 0.0 || M2 < 1e-9 * old_M2) {
+                        size_t vc_r = 0;
+                        price_t mean_r = 0.0, M2_r = 0.0;
+                        size_t lo = i - static_cast<size_t>(n) + 1;
+                        for (size_t j = lo; j < i; ++j) {
+                            if (!std::isnan(src[j])) {
+                                vc_r++;
+                                if (vc_r == 1) {
+                                    mean_r = src[j];
+                                } else {
+                                    price_t d = src[j] - mean_r;
+                                    mean_r += d / vc_r;
+                                    M2_r += d * (src[j] - mean_r);
+                                }
+                            }
+                        }
+                        valid_count = vc_r;
+                        mean = mean_r;
+                        M2 = M2_r;
+                    }
+                } else {
+                    mean = 0.0;
+                    M2 = 0.0;
+                    valid_count = 0;
                 }
             }
-            if (j == i) {
-                continue;
+        }
+        price_t entering = src[i];
+        if (!std::isnan(entering)) {
+            valid_count++;
+            if (valid_count == 1) {
+                mean = entering;
+                M2 = 0.0;
+            } else {
+                price_t delta = entering - mean;
+                mean += delta / valid_count;
+                M2 += delta * (entering - mean);
             }
-            ex -= src[j] - k;
-            ex2 -= pow_buf[j + n - start_pos];
-            price_t d = src[i] - k;
-            ex += d;
-            price_t d_pow = std::pow(d, 2);
-            pow_buf[i + n - start_pos] = d_pow;
-            ex2 += d_pow;
-            num = i - j;
-            if (num != 1) {
-                dst[i] = std::sqrt((ex2 - std::pow(ex, 2) / num) / (num - 1));
-            }
+        }
+        if (i >= start_pos && valid_count > 1) {
+            dst[i] = std::sqrt(M2 / (valid_count - 1));
         }
     }
 }
 
 void IStdev::_dyn_run_one_step(const Indicator& ind, size_t curPos, size_t step) {
     size_t start = _get_step_start(curPos, step, ind.discard());
-    size_t num = 0;
-    price_t ex = 0.0, ex2 = 0.0;
-    price_t k = ind[start];
+    // 单趟 Welford（动态窗口左边界跳变，不用 remove，无重算需求）
+    size_t valid_count = 0;
+    price_t mean = 0.0;
+    price_t M2 = 0.0;
     for (size_t i = start; i <= curPos; i++) {
-        num++;
-        price_t d = ind[i] - k;
-        ex += d;
-        ex2 += std::pow(d, 2);
+        if (!std::isnan(ind[i])) {
+            valid_count++;
+            if (valid_count == 1) {
+                mean = ind[i];
+                M2 = 0.0;
+            } else {
+                price_t delta = ind[i] - mean;
+                mean += delta / valid_count;
+                M2 += delta * (ind[i] - mean);
+            }
+        }
     }
-    _set(num <= 1 ? 0.0 : std::sqrt((ex2 - std::pow(ex, 2) / num) / (num - 1)), curPos);
+    if (valid_count > 1) {
+        _set(std::sqrt(M2 / (valid_count - 1)), curPos);
+    }
 }
 
 Indicator HKU_API STDEV(int n) {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_ICIR_nan_consistency.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_ICIR_nan_consistency.cpp
@@ -1,0 +1,76 @@
+/*
+ * test_ICIR_nan_consistency.cpp
+ *
+ * 验证 MA(ic,n) / STDEV(ic,n) 组合在含散布 NaN 时的语义一致性。
+ * ICIR = MA / STDEV，分子分母必须基于完全相同的有效样本集，
+ * 且任一为 NaN 时 ICIR 必须静默输出 NaN（不抛浮点除零异常）。
+ */
+
+#include "../test_config.h"
+#include <hikyuu/indicator/crt/PRICELIST.h>
+#include <hikyuu/indicator/crt/MA.h>
+#include <hikyuu/indicator/crt/STDEV.h>
+
+using namespace hku;
+
+/**
+ * @defgroup test_indicator_ICIR_nan test_indicator_ICIR_nan
+ * @ingroup test_hikyuu_indicator_suite
+ * @{
+ */
+
+/** @par 检测点：MA/STDEV 组合 ICIR 在含 NaN 时的一致性 */
+TEST_CASE("test_ICIR_nan_consistency") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(5.0);
+    d.push_back(6.0);
+    d.push_back(7.0);
+    d.push_back(8.0);
+
+    Indicator ic = PRICELIST(d);
+    int n = 4;
+    Indicator ma = MA(ic, n);
+    Indicator std = STDEV(ic, n);
+    // ICIR = MA / STDEV（ICIR.h 内部即此组合）
+    Indicator ir = ma / std;
+
+    CHECK_EQ(ir.size(), ma.size());
+    CHECK_EQ(ir.discard(), ma.discard());
+
+    for (size_t i = 0; i < ir.size(); ++i) {
+        if (std::isnan(ma[i]) || std::isnan(std[i]) || std[i] == 0.0) {
+            // 任一为 NaN 或 std=0 时，ICIR 必须为 NaN（不抛异常，不产生 Inf）
+            CHECK_UNARY(std::isnan(ir[i]));
+        } else {
+            // 两者均有效时，ICIR = ma/std
+            CHECK_EQ(ir[i], doctest::Approx(ma[i] / std[i]).epsilon(0.0001));
+        }
+    }
+}
+
+/** @par 检测点：count=1 时 std=NaN，ICIR 静默 NaN（不除零崩溃） */
+TEST_CASE("test_ICIR_count1_silent_nan") {
+    PriceList d;
+    for (int i = 0; i < 7; ++i) {
+        d.push_back(Null<price_t>());
+    }
+    d[3] = 5.0;  // 唯一有效值
+
+    Indicator ic = PRICELIST(d);
+    Indicator ma = MA(ic, 4);
+    Indicator std = STDEV(ic, 4);
+    Indicator ir = ma / std;
+
+    // MA 有值（5.0），但 std=NaN（count=1），ICIR 必须静默 NaN
+    for (size_t i = ir.discard(); i < ir.size(); ++i) {
+        CHECK_UNARY(std::isnan(std[i]));
+        // 不允许 Inf 或异常
+        CHECK_UNARY(std::isnan(ir[i]));
+    }
+}
+
+/** @} */

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
@@ -239,4 +239,186 @@ TEST_CASE("test_MA_export") {
 }
 #endif /* #if HKU_SUPPORT_SERIALIZATION */
 
+//----------------------------------------------------------------------------
+// NaN 语义测试（Welford 滚动均值，与 IStdev 共用 valid_count 逻辑）
+//----------------------------------------------------------------------------
+
+/** @par 检测点：散布 NaN 的滚动均值 */
+TEST_CASE("test_MA_nan_scattered") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(5.0);
+    d.push_back(6.0);
+    d.push_back(7.0);
+    d.push_back(8.0);
+    d.push_back(9.0);
+    d.push_back(10.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator ma = MA(ind, 4);
+    CHECK_EQ(ma.discard(), 3);
+    CHECK_EQ(ma.size(), 10);
+    for (size_t i = 0; i < ma.discard(); ++i) {
+        CHECK_UNARY(std::isnan(ma[i]));
+    }
+    // 窗口 [1,2,3,NaN] → vc=3, mean=2.0
+    CHECK_EQ(ma[3], doctest::Approx(2.0).epsilon(0.0001));
+    // 窗口 [2,3,NaN,5] → vc=3, mean=10/3
+    CHECK_EQ(ma[4], doctest::Approx(3.333333).epsilon(0.0001));
+    // 窗口 [3,NaN,5,6] → vc=3, mean=14/3
+    CHECK_EQ(ma[5], doctest::Approx(4.666667).epsilon(0.0001));
+    // 窗口 [NaN,5,6,7] → vc=3, mean=6.0（NaN 离开后恢复）
+    CHECK_EQ(ma[6], doctest::Approx(6.0).epsilon(0.0001));
+    // 窗口 [5,6,7,8] → vc=4, mean=6.5（全有效）
+    CHECK_EQ(ma[7], doctest::Approx(6.5).epsilon(0.0001));
+    CHECK_EQ(ma[8], doctest::Approx(7.5).epsilon(0.0001));
+    CHECK_EQ(ma[9], doctest::Approx(8.5).epsilon(0.0001));
+}
+
+/** @par 检测点：连续 NaN 穿越后状态恢复 */
+TEST_CASE("test_MA_nan_consecutive") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(3.0);
+    d.push_back(4.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator ma = MA(ind, 3);
+    CHECK_EQ(ma.discard(), 2);
+    // i=2 窗口 [1,2,NaN] → vc=2, mean=1.5
+    CHECK_EQ(ma[2], doctest::Approx(1.5).epsilon(0.0001));
+    // i=3 窗口 [2,NaN,NaN] → vc=1, mean=2.0
+    CHECK_EQ(ma[3], doctest::Approx(2.0).epsilon(0.0001));
+    // i=4 窗口 [NaN,NaN,NaN] → vc=0, mean=NaN
+    CHECK_UNARY(std::isnan(ma[4]));
+    // i=5 窗口 [NaN,NaN,3] → vc=1, mean=3.0（从 0 重建）
+    CHECK_EQ(ma[5], doctest::Approx(3.0).epsilon(0.0001));
+    // i=6 窗口 [NaN,3,4] → vc=2, mean=3.5（恢复）
+    CHECK_EQ(ma[6], doctest::Approx(3.5).epsilon(0.0001));
+}
+
+/** @par 检测点：窗口仅 1 个有效值（count=1 边界） */
+TEST_CASE("test_MA_nan_single_valid") {
+    PriceList d;
+    for (int i = 0; i < 7; ++i) {
+        d.push_back(Null<price_t>());  // NaN
+    }
+    d[3] = 5.0;  // 唯一有效值
+
+    Indicator ind = PRICELIST(d);
+    Indicator ma = MA(ind, 4);
+    CHECK_EQ(ma.discard(), 3);
+    // vc 恒=1，输出该有效值本身
+    CHECK_EQ(ma[3], doctest::Approx(5.0).epsilon(0.0001));
+    CHECK_EQ(ma[4], doctest::Approx(5.0).epsilon(0.0001));
+    CHECK_EQ(ma[5], doctest::Approx(5.0).epsilon(0.0001));
+    CHECK_EQ(ma[6], doctest::Approx(5.0).epsilon(0.0001));
+}
+
+/** @par 检测点：大基数小方差（Welford 精度验证） */
+TEST_CASE("test_MA_large_base") {
+    PriceList d;
+    double base = 1e8;
+    for (int i = 1; i <= 5; ++i) {
+        d.push_back(base + i);
+    }
+
+    Indicator ind = PRICELIST(d);
+    Indicator ma = MA(ind, 3);
+    CHECK_EQ(ma.discard(), 2);
+    // 窗口 [1e8+1,1e8+2,1e8+3] → mean=1e8+2
+    CHECK_EQ(ma[2], doctest::Approx(100000002.0).epsilon(0.0001));
+    CHECK_EQ(ma[3], doctest::Approx(100000003.0).epsilon(0.0001));
+    CHECK_EQ(ma[4], doctest::Approx(100000004.0).epsilon(0.0001));
+}
+
+/** @par 检测点：极小窗口 n=2 */
+TEST_CASE("test_MA_n2") {
+    PriceList d;
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(5.0);
+    d.push_back(7.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator ma = MA(ind, 2);
+    CHECK_EQ(ma.discard(), 1);
+    // i=1 窗口 [3,NaN] → vc=1, mean=3.0
+    CHECK_EQ(ma[1], doctest::Approx(3.0).epsilon(0.0001));
+    // i=2 窗口 [NaN,5] → vc=1, mean=5.0
+    CHECK_EQ(ma[2], doctest::Approx(5.0).epsilon(0.0001));
+    // i=3 窗口 [5,7] → vc=2, mean=6.0
+    CHECK_EQ(ma[3], doctest::Approx(6.0).epsilon(0.0001));
+}
+
+/** @par 检测点：全 NaN 序列不死循环不抛异常 */
+TEST_CASE("test_MA_all_nan") {
+    PriceList d;
+    for (int i = 0; i < 4; ++i) {
+        d.push_back(Null<price_t>());
+    }
+    Indicator ind = PRICELIST(d);
+    Indicator ma = MA(ind, 3);
+    CHECK_EQ(ma.size(), 4);
+    for (size_t i = 0; i < ma.size(); ++i) {
+        CHECK_UNARY(std::isnan(ma[i]));
+    }
+}
+
+/** @par 检测点：上游 discard 传递 */
+TEST_CASE("test_MA_upstream_discard") {
+    PriceList d;
+    for (int i = 0; i < 10; ++i) {
+        d.push_back(i + 1);
+    }
+    // 构造上游 discard=4：前4个置 NaN
+    for (int i = 0; i < 4; ++i) {
+        d[i] = Null<price_t>();
+    }
+    Indicator ind = PRICELIST(d);
+    ind.setDiscard(4);  // 显式声明 discard
+
+    Indicator ma = MA(ind, 3);
+    // m_discard = 4 + 3 - 1 = 6
+    CHECK_EQ(ma.discard(), 6);
+    for (size_t i = 0; i < ma.discard(); ++i) {
+        CHECK_UNARY(std::isnan(ma[i]));
+    }
+    // i=6 窗口 [5,6,7] → mean=6.0
+    CHECK_EQ(ma[6], doctest::Approx(6.0).epsilon(0.0001));
+    CHECK_EQ(ma[7], doctest::Approx(7.0).epsilon(0.0001));
+}
+
+/** @par 检测点：_dyn 动态路径与静态 n 等价（含 NaN） */
+TEST_CASE("test_MA_dyn_nan_equivalence") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());
+    d.push_back(5.0);
+    d.push_back(6.0);
+    d.push_back(7.0);
+    d.push_back(8.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator expect = MA(ind, 4);
+    Indicator result = MA(ind, CVAL(ind, 4));
+    CHECK_EQ(expect.size(), result.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+        if (std::isnan(expect[i])) {
+            CHECK_UNARY(std::isnan(result[i]));
+        } else {
+            CHECK_EQ(result[i], doctest::Approx(expect[i]).epsilon(0.0001));
+        }
+    }
+}
+
 /** @} */

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
@@ -412,10 +412,9 @@ TEST_CASE("test_MA_dyn_nan_equivalence") {
     Indicator expect = MA(ind, 4);
     Indicator result = MA(ind, CVAL(ind, 4));
     CHECK_EQ(expect.size(), result.size());
-    // _dyn 路径的 discard 由 updateDiscard 自动检测，与静态 m_discard 可能不同
-    // 只验证两者 common discard 之后的位置值一致
-    size_t common_discard = std::max(expect.discard(), result.discard());
-    for (size_t i = common_discard; i < result.size(); ++i) {
+    // _dyn 路径 discard 与静态一致（均有窗口未满 guard）
+    CHECK_EQ(expect.discard(), result.discard());
+    for (size_t i = 0; i < result.size(); ++i) {
         if (std::isnan(expect[i])) {
             CHECK_UNARY(std::isnan(result[i]));
         } else {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
@@ -49,6 +49,31 @@ TEST_CASE("test_MA") {
         CHECK_EQ(ma[i], doctest::Approx(expects[i]).epsilon(0.0001));
     }
 
+    /** @arg n = 0 且数据含 interior NaN（valid_count 分母正确性） */
+    {
+        PriceList d_nan;
+        d_nan.push_back(1.0);
+        d_nan.push_back(2.0);
+        d_nan.push_back(Null<price_t>());  // NaN
+        d_nan.push_back(4.0);
+        d_nan.push_back(Null<price_t>());  // NaN
+        d_nan.push_back(6.0);
+        Indicator ind_nan = PRICELIST(d_nan);
+        Indicator ma_nan = MA(ind_nan, 0);
+        // i=0: sum=1, vc=1, mean=1.0
+        CHECK_EQ(ma_nan[0], doctest::Approx(1.0).epsilon(0.0001));
+        // i=1: sum=3, vc=2, mean=1.5
+        CHECK_EQ(ma_nan[1], doctest::Approx(1.5).epsilon(0.0001));
+        // i=2: NaN skip, 不输出（vc 不变）
+        CHECK_UNARY(std::isnan(ma_nan[2]));
+        // i=3: sum=7, vc=3, mean=7/3≈2.333（旧 bug 会算 7/4=1.75）
+        CHECK_EQ(ma_nan[3], doctest::Approx(2.333333).epsilon(0.0001));
+        // i=4: NaN skip
+        CHECK_UNARY(std::isnan(ma_nan[4]));
+        // i=5: sum=13, vc=4, mean=13/4=3.25（旧 bug 会算 13/6≈2.167）
+        CHECK_EQ(ma_nan[5], doctest::Approx(3.25).epsilon(0.0001));
+    }
+
     /** @arg n = 10 且数据大小刚好为10 时, 正常关联数据 */
     kdata = stock.getKData(KQuery(-10));
     open = OPEN(kdata);

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_MA.cpp
@@ -412,7 +412,10 @@ TEST_CASE("test_MA_dyn_nan_equivalence") {
     Indicator expect = MA(ind, 4);
     Indicator result = MA(ind, CVAL(ind, 4));
     CHECK_EQ(expect.size(), result.size());
-    for (size_t i = 0; i < result.size(); ++i) {
+    // _dyn 路径的 discard 由 updateDiscard 自动检测，与静态 m_discard 可能不同
+    // 只验证两者 common discard 之后的位置值一致
+    size_t common_discard = std::max(expect.discard(), result.discard());
+    for (size_t i = common_discard; i < result.size(); ++i) {
         if (std::isnan(expect[i])) {
             CHECK_UNARY(std::isnan(result[i]));
         } else {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
@@ -318,11 +318,9 @@ TEST_CASE("test_STDEV_dyn_nan_equivalence") {
     Indicator expect = STDEV(ind, 4);
     Indicator result = STDEV(ind, CVAL(ind, 4));
     CHECK_EQ(expect.size(), result.size());
-    // _dyn 路径的 discard 由 updateDiscard 自动检测，与静态 m_discard 可能不同
-    // （既有设计，见 test_STDEV_dyn 中注释掉的 discard 检查）
-    // 只验证两者 common discard 之后的位置值一致
-    size_t common_discard = std::max(expect.discard(), result.discard());
-    for (size_t i = common_discard; i < result.size(); ++i) {
+    // _dyn 路径加了窗口未满 guard，discard 与静态一致
+    CHECK_EQ(expect.discard(), result.discard());
+    for (size_t i = 0; i < result.size(); ++i) {
         if (std::isnan(expect[i])) {
             CHECK_UNARY(std::isnan(result[i]));
         } else {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
@@ -318,7 +318,11 @@ TEST_CASE("test_STDEV_dyn_nan_equivalence") {
     Indicator expect = STDEV(ind, 4);
     Indicator result = STDEV(ind, CVAL(ind, 4));
     CHECK_EQ(expect.size(), result.size());
-    for (size_t i = 0; i < result.size(); ++i) {
+    // _dyn 路径的 discard 由 updateDiscard 自动检测，与静态 m_discard 可能不同
+    // （既有设计，见 test_STDEV_dyn 中注释掉的 discard 检查）
+    // 只验证两者 common discard 之后的位置值一致
+    size_t common_discard = std::max(expect.discard(), result.discard());
+    for (size_t i = common_discard; i < result.size(); ++i) {
         if (std::isnan(expect[i])) {
             CHECK_UNARY(std::isnan(result[i]));
         } else {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
@@ -331,4 +331,30 @@ TEST_CASE("test_STDEV_dyn_nan_equivalence") {
     }
 }
 
+/** @par 检测点：n=1 参数被拦截（样本标准差无定义，抛异常而非 Inf/崩溃） */
+TEST_CASE("test_STDEV_n1_rejected") {
+    PriceList d;
+    for (int i = 0; i < 5; ++i) {
+        d.push_back(i + 1);
+    }
+    Indicator ind = PRICELIST(d);
+    // n=1: 样本方差除以 N-1=0，_checkParam 拦截（HKU_ASSERT(n==0 || n>=2)）
+    CHECK_THROWS_AS(STDEV(ind, 1), std::exception);
+}
+
+/** @par 检测点：常数序列 Zero Variance（浮点噪声防御） */
+TEST_CASE("test_STDEV_zero_variance") {
+    PriceList d;
+    for (int i = 0; i < 5; ++i) {
+        d.push_back(3.14);
+    }
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 3);
+    CHECK_EQ(dev.discard(), 2);
+    // 常数序列方差=0，浮点噪声可能让 M2 微负，max(0,...) 防御确保输出 0.0 而非 NaN
+    for (size_t i = dev.discard(); i < dev.size(); ++i) {
+        CHECK_EQ(dev[i], doctest::Approx(0.0).epsilon(0.0001));
+    }
+}
+
 /** @} */

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_STDEV.cpp
@@ -34,13 +34,16 @@ TEST_CASE("test_STDEV") {
 
     Indicator ind = PRICELIST(d);
     Indicator dev = STDEV(ind, 10);
-    CHECK_EQ(dev.discard(), 1);
+    // BREAKING CHANGE: discard 从 1 改为 data.discard()+n-1=9（窗口未满输出 NaN）
+    CHECK_EQ(dev.discard(), 9);
     CHECK_EQ(dev.size(), 15);
 
-    vector<price_t> expected{0,       0.707107, 1,       1.29099, 1.58114,
-                             1.47196, 1.97605,  1.83225, 2.44949, 2.92309,
-                             3.14289, 2.83039,  3.26769, 3.653,   4.00139};
-    CHECK_UNARY(std::isnan(dev[0]));
+    // 窗口未满（i<9）输出 NaN；i>=9 稳态值与旧实现一致（Welford 精度内）
+    vector<price_t> expected{0, 0, 0, 0, 0, 0, 0, 0, 0, 2.92309, 3.14289, 2.83039,
+                             3.26769, 3.653, 4.00139};
+    for (size_t i = 0; i < dev.discard(); ++i) {
+        CHECK_UNARY(std::isnan(dev[i]));
+    }
     for (size_t i = dev.discard(); i < dev.size(); i++) {
         CHECK_EQ(dev[i], doctest::Approx(expected[i]).epsilon(0.0001));
     }
@@ -121,5 +124,207 @@ TEST_CASE("test_STDEV_export") {
     }
 }
 #endif /* #if HKU_SUPPORT_SERIALIZATION */
+
+//----------------------------------------------------------------------------
+// NaN 语义测试（Welford 滚动方差 + 离群值离开条件重算）
+//----------------------------------------------------------------------------
+
+/** @par 检测点：散布 NaN 的滚动标准差 */
+TEST_CASE("test_STDEV_nan_scattered") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());  // NaN
+    d.push_back(5.0);
+    d.push_back(6.0);
+    d.push_back(7.0);
+    d.push_back(8.0);
+    d.push_back(9.0);
+    d.push_back(10.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 4);
+    CHECK_EQ(dev.discard(), 3);
+    for (size_t i = 0; i < dev.discard(); ++i) {
+        CHECK_UNARY(std::isnan(dev[i]));
+    }
+    // i=3 窗口 [1,2,3,NaN] → vc=3, std=std(1,2,3)=1.0
+    CHECK_EQ(dev[3], doctest::Approx(1.0).epsilon(0.0001));
+    // i=4 窗口 [2,3,NaN,5] → vc=3, std=std(2,3,5)=1.527525
+    CHECK_EQ(dev[4], doctest::Approx(1.527525).epsilon(0.0001));
+    // i=5 窗口 [3,NaN,5,6] → vc=3, std=std(3,5,6)=1.527525
+    CHECK_EQ(dev[5], doctest::Approx(1.527525).epsilon(0.0001));
+    // i=6 窗口 [NaN,5,6,7] → vc=3, std=std(5,6,7)=1.0（恢复）
+    CHECK_EQ(dev[6], doctest::Approx(1.0).epsilon(0.0001));
+    // i=7 窗口 [5,6,7,8] → vc=4, std=std(5,6,7,8)=1.290994
+    CHECK_EQ(dev[7], doctest::Approx(1.290994).epsilon(0.0001));
+    CHECK_EQ(dev[8], doctest::Approx(1.290994).epsilon(0.0001));
+    CHECK_EQ(dev[9], doctest::Approx(1.290994).epsilon(0.0001));
+}
+
+/** @par 检测点：连续 NaN 穿越后状态恢复 */
+TEST_CASE("test_STDEV_nan_consecutive") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(Null<price_t>());
+    d.push_back(Null<price_t>());
+    d.push_back(Null<price_t>());
+    d.push_back(3.0);
+    d.push_back(4.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 3);
+    CHECK_EQ(dev.discard(), 2);
+    // i=2 窗口 [1,2,NaN] → vc=2, std=std(1,2)=0.707107
+    CHECK_EQ(dev[2], doctest::Approx(0.707107).epsilon(0.0001));
+    // i=3 窗口 [2,NaN,NaN] → vc=1, std=NaN
+    CHECK_UNARY(std::isnan(dev[3]));
+    // i=4 窗口 [NaN,NaN,NaN] → vc=0, std=NaN
+    CHECK_UNARY(std::isnan(dev[4]));
+    // i=5 窗口 [NaN,NaN,3] → vc=1, std=NaN（从 0 重建）
+    CHECK_UNARY(std::isnan(dev[5]));
+    // i=6 窗口 [NaN,3,4] → vc=2, std=std(3,4)=0.707107（恢复）
+    CHECK_EQ(dev[6], doctest::Approx(0.707107).epsilon(0.0001));
+}
+
+/** @par 检测点：窗口仅 1 个有效值（count=1，std=NaN 而非 Inf/异常） */
+TEST_CASE("test_STDEV_nan_single_valid") {
+    PriceList d;
+    for (int i = 0; i < 7; ++i) {
+        d.push_back(Null<price_t>());
+    }
+    d[3] = 5.0;
+
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 4);
+    CHECK_EQ(dev.discard(), 3);
+    // vc 恒=1，std 恒 NaN（样本方差除以 0，安全返回 NaN）
+    for (size_t i = dev.discard(); i < dev.size(); ++i) {
+        CHECK_UNARY(std::isnan(dev[i]));
+    }
+}
+
+/** @par 检测点：大基数小方差（Welford 精度验证） */
+TEST_CASE("test_STDEV_large_base") {
+    PriceList d;
+    double base = 1e8;
+    for (int i = 1; i <= 5; ++i) {
+        d.push_back(base + i);
+    }
+
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 3);
+    CHECK_EQ(dev.discard(), 2);
+    // 窗口 [1e8+1,1e8+2,1e8+3] → std=1.0（精确，Welford 消除大基数）
+    CHECK_EQ(dev[2], doctest::Approx(1.0).epsilon(0.0001));
+    CHECK_EQ(dev[3], doctest::Approx(1.0).epsilon(0.0001));
+    CHECK_EQ(dev[4], doctest::Approx(1.0).epsilon(0.0001));
+}
+
+/** @par 检测点：离群值离开窗口触发重算（精度恢复） */
+TEST_CASE("test_STDEV_outlier_leaving_rescan") {
+    PriceList d;
+    d.push_back(10.0);
+    d.push_back(10.0);
+    d.push_back(10.0);
+    d.push_back(1e6);  // 离群值
+    d.push_back(2.0);
+    d.push_back(4.0);
+    d.push_back(4.0);
+    d.push_back(4.0);
+    d.push_back(5.0);
+    d.push_back(5.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 5);
+    CHECK_EQ(dev.discard(), 4);
+    // i=8 离群值 1e6 离开窗口，窗口 [2,4,4,4,5]
+    // 真实 std = sqrt(1.2) ≈ 1.095445，重算必须精确恢复
+    CHECK_EQ(dev[8], doctest::Approx(1.095445).epsilon(0.00001));
+    // i=9 窗口 [4,4,4,5,5] → std=0.547723
+    CHECK_EQ(dev[9], doctest::Approx(0.547723).epsilon(0.0001));
+}
+
+/** @par 检测点：极小窗口 n=2 */
+TEST_CASE("test_STDEV_n2") {
+    PriceList d;
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());
+    d.push_back(5.0);
+    d.push_back(7.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 2);
+    CHECK_EQ(dev.discard(), 1);
+    // i=1 窗口 [3,NaN] → vc=1, std=NaN
+    CHECK_UNARY(std::isnan(dev[1]));
+    // i=2 窗口 [NaN,5] → vc=1, std=NaN
+    CHECK_UNARY(std::isnan(dev[2]));
+    // i=3 窗口 [5,7] → vc=2, std=std(5,7)=1.414214
+    CHECK_EQ(dev[3], doctest::Approx(1.414214).epsilon(0.0001));
+}
+
+/** @par 检测点：全 NaN 序列不死循环不抛异常 */
+TEST_CASE("test_STDEV_all_nan") {
+    PriceList d;
+    for (int i = 0; i < 4; ++i) {
+        d.push_back(Null<price_t>());
+    }
+    Indicator ind = PRICELIST(d);
+    Indicator dev = STDEV(ind, 3);
+    CHECK_EQ(dev.size(), 4);
+    for (size_t i = 0; i < dev.size(); ++i) {
+        CHECK_UNARY(std::isnan(dev[i]));
+    }
+}
+
+/** @par 检测点：上游 discard 传递 */
+TEST_CASE("test_STDEV_upstream_discard") {
+    PriceList d;
+    for (int i = 0; i < 10; ++i) {
+        d.push_back(i + 1);
+    }
+    for (int i = 0; i < 4; ++i) {
+        d[i] = Null<price_t>();
+    }
+    Indicator ind = PRICELIST(d);
+    ind.setDiscard(4);
+
+    Indicator dev = STDEV(ind, 3);
+    // m_discard = 4 + 3 - 1 = 6
+    CHECK_EQ(dev.discard(), 6);
+    for (size_t i = 0; i < dev.discard(); ++i) {
+        CHECK_UNARY(std::isnan(dev[i]));
+    }
+    // i=6 窗口 [5,6,7] → std=1.0
+    CHECK_EQ(dev[6], doctest::Approx(1.0).epsilon(0.0001));
+}
+
+/** @par 检测点：_dyn 动态路径与静态 n 等价（含 NaN） */
+TEST_CASE("test_STDEV_dyn_nan_equivalence") {
+    PriceList d;
+    d.push_back(1.0);
+    d.push_back(2.0);
+    d.push_back(3.0);
+    d.push_back(Null<price_t>());
+    d.push_back(5.0);
+    d.push_back(6.0);
+    d.push_back(7.0);
+    d.push_back(8.0);
+
+    Indicator ind = PRICELIST(d);
+    Indicator expect = STDEV(ind, 4);
+    Indicator result = STDEV(ind, CVAL(ind, 4));
+    CHECK_EQ(expect.size(), result.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+        if (std::isnan(expect[i])) {
+            CHECK_UNARY(std::isnan(result[i]));
+        } else {
+            CHECK_EQ(result[i], doctest::Approx(expect[i]).epsilon(0.0001));
+        }
+    }
+}
 
 /** @} */


### PR DESCRIPTION
## 问题概述

`MA` 与 `STDEV` 对输入序列内部 NaN 的处理策略完全不同。两者在 4 处被组合为 `MA(ic, n) / STDEV(ic, n)` 计算 ICIR，当 IC 序列含散布 NaN 时（回测中部分股票某日缺因子值/收益即触发），分子分母基于不一致的有效样本集，ICIR 值无数学意义——是静默数值污染，非崩溃。

具体表现为：MA 的 mean 基于固定 n 个样本（NaN 被跳过但除以 n），STDEV 的 std 基于重算的 num ≠ n 个样本，`MA(ic,n) / STDEV(ic,n)` 的分子分母有效样本集不一致。且 MA 遇 NaN leaving 时整步跳过、entering 永不加入 sum，sum 永久损坏不可恢复。

## 根因分析

### IMa（n>0 滚动分支）

初始窗口累加跳过 NaN 但**除以固定 n**（`IMa.cpp:64-70`）：

$$\text{MA}_i = \frac{\sum_{j \in \text{window, non-NaN}} x_j}{n} \quad (\text{分母固定 } n, \text{ 非 vc})$$

滚动更新仅当 entering 和 leaving **均非 NaN** 时才执行（`IMa.cpp:72-77`）：

```cpp
for (size_t i = m_discard + 1; i < total; ++i) {
    if (!std::isnan(src[i]) && !std::isnan(src[i - n])) {   // both must be non-NaN
        sum = src[i] + sum - src[i - n];
        dst[i] = sum / n;
    }
}
```

当 `src[i-n]`（leaving）为 NaN 时整步被 skip，**entering `src[i]` 永不加入 sum**。sum 在此后永久损坏，后续窗口的 mean 全部错误。语义为"NaN 视为 0 参与 sum，除以 n；遇 NaN leaving 则断链且不恢复"。

### IStdev（n>0 滚动分支）

初始窗口计实际非 NaN 数 `num`，除以 `num`/`num-1`（`IStdev.cpp:52-65`）。滚动更新扫描 `[i-n, i)` 找第一个非 NaN leaving，重算 `num = i - j`（`IStdev.cpp:67-92`）：

$$\text{STDEV}_i = \sqrt{\frac{\text{ex2} - \text{ex}^2 / \text{num}}{\text{num} - 1}}, \quad \text{num} = i - j \neq n$$

```cpp
for (size_t i = first_end; i < total; i++) {
    if (!std::isnan(src[i])) {
        size_t j = i - n;
        for (; j < i; j++) { if (!std::isnan(src[j])) break; }  // scan for non-NaN leaving
        if (j == i) { continue; }
        ex -= src[j] - k;          // remove scanned leaving
        ex2 -= pow_buf[j];
        // …add entering…
        num = i - j;               // recompute num
        dst[i] = std::sqrt((ex2 - std::pow(ex, 2) / num) / (num - 1));
    }
}
```

语义为"leaving 找最近非 NaN，num 重算"。但这并非真正"可恢复"：当 entering `src[i]` 为 NaN 时整步 skip，leaving 端已找到的元素未减出 ex/ex2，造成 stale 累积；`num = i - j` 对内部 NaN 会多算（假设窗口满）。即 STDEV 也是错的，只是错法与 MA 不同。

### 两者对 NaN 的处理策略对比

| 维度 | MA | STDEV |
|------|-----|-------|
| NaN leaving 处理 | 直接用 `src[i-n]`，是 NaN 就跳过 | 扫描 `[i-n, i)` 找第一个非 NaN leaving |
| 有效样本数 | 固定 n（除以 n） | 重算 `num = i - j`（实际有效数） |
| 断链后恢复 | 不恢复，sum 废弃 | 每次重新找有效 leaving，可恢复（但有 stale 累积） |

反例追踪：`ic = [1,2,3,NaN,5,6,7,8,9,10]`, n=4

| i | 窗口 | MA（旧） | STDEV（旧） | 正确 mean | 正确 std |
|---|------|---------|------------|-----------|----------|
| 3 | [1,2,3,NaN] | 1.5 (6/4) | 1.0 (num=3) | 2.0 (6/3) | 1.0 |
| 7 | [NaN,5,6,7] | skip→NaN, sum 损坏 | num=4 | 6.0 | 0.816 |
| 8 | [5,6,7,8] | 5.5 ❌（损坏 sum 22/4） | num=4 | 6.5 | 1.118 |

i=8：MA 输出 5.5（错误，i=7 时丢失 `+8` 且未恢复），正确 mean 为 6.5。`MA/STDEV` 比率混合了分子（NaN 视为 0、断链不恢复）和分母（扫描法、num 重算但 stale 累积），**无数学意义**。

### IMa 内部自身不一致与 n<=0 分母 bug

`n <= 0` 全量分支（`IMa.cpp:42-47`）除以 `(i - m_discard + 1)`（物理元素跨度），`n > 0` 分支除以固定 n，一个指标两种语义。且 `n <= 0` 分支的分母 `i - m_discard + 1` 在含 interior NaN 时大于实际非 NaN 数（NaN 跳过累加但物理跨度仍计数），导致 mean 被异常缩小。本 PR 将 `n <= 0` 分母改为 `valid_count`（实际非 NaN 计数），与 `n > 0` 的 Welford valid-mean 语义统一。

### ICIR 消费点（共 4 处）

`ICIR.h:35`（StockList overload）、`ICIR.h:45`（Block overload）、`MultiFactorBase.cpp:480`（`getICIR`）、`ICIRMultiFactor.cpp:58`（`_calculate`），全部 `MA(ic, n) / STDEV(ic, n)` 组合。

> **关联**：PR #484（Spearman tie-handling）的"已知局限"第 1 条已预判本问题："`IMa.cpp` 滚动段任一 NaN 则该窗口输出 NaN…后续方向：独立 issue 修复 `IMa.cpp` 的 NaN 状态管理，并统一 MA/STDEV 对 NaN 的处理口径。" 本 PR 即为该后续修复。

## 修复方案

### 核心策略：NaN 感知 valid mean/std

MA 和 STDEV 在窗口内严格维护 `valid_count`（非 NaN 元素数），基于**完全一致**的 valid_count 计算均值和标准差：

$$\text{MA}_i = \begin{cases} \text{mean}_i & \text{vc}_i > 0 \\ \text{NaN} & \text{otherwise} \end{cases}$$

$$\text{STDEV}_i = \begin{cases} \sqrt{\frac{M2_i}{\text{vc}_i - 1}} & \text{vc}_i > 1 \\ \text{NaN} & \text{otherwise} \end{cases}$$

其中 mean 和 M2 由 Welford 在线算法维护，$\text{vc}_i$ 为窗口 $W_i$ 中非 NaN 元素个数（valid_count）。两者共用字符级一致的 valid_count/mean 更新逻辑（Add/Remove），保证 ICIR 分子分母基于完全相同的样本集：

$$\text{ICIR}_i = \frac{\text{MA}_i}{\text{STDEV}_i} = \frac{\text{mean}_i}{\sqrt{M2_i / (\text{vc}_i - 1)}}$$

分子分母共享同一个 $\text{vc}_i$ 和 $\text{mean}_i$，数学上严格一致。

### Welford O(1) 出入队更新

Welford 算法通过始终围绕当前动态均值计算残差 $\delta = x - \text{mean}$，天生免疫大基数小方差问题（残差在第一步就消除了共性基数）。Add/Remove 互为代数逆运算：

**Add**（加入 entering $x$）：

$$\text{vc} \leftarrow \text{vc} + 1, \quad \delta = x - \text{mean}, \quad \text{mean} \leftarrow \text{mean} + \frac{\delta}{\text{vc}}, \quad M2 \leftarrow M2 + \delta \cdot (x - \text{mean})$$

**Remove**（移除 leaving $x$，vc > 1 时）：

$$\delta = x - \text{mean}, \quad \text{mean} \leftarrow \text{mean} - \frac{\delta}{\text{vc} - 1}, \quad M2 \leftarrow M2 - \delta \cdot (x - \text{mean}), \quad \text{vc} \leftarrow \text{vc} - 1$$

其中 $M2 = \sum_{j \in \text{valid}} (x_j - \text{mean})^2$ 为二阶矩，样本方差 $s^2 = M2 / (\text{vc} - 1)$。

```cpp
// ---- Remove leaving（非 NaN 时）----
if (valid_count > 1) {
    price_t delta = leaving - mean;
    mean -= delta / (valid_count - 1);
    M2 -= delta * (leaving - mean);       // STDEV only
    valid_count--;
} else {                                   // valid_count == 1，窗口归零
    mean = 0.0; M2 = 0.0; valid_count = 0;
}

// ---- Add entering（非 NaN 时）----
valid_count++;
if (valid_count == 1) {
    mean = entering; M2 = 0.0;
} else {
    price_t delta = entering - mean;
    mean += delta / valid_count;
    M2 += delta * (entering - mean);       // STDEV only
}
```

操作顺序（先 Remove 后 Add）保证 valid_count 在极低水平波动（1→0→1）时状态机确定可控。`valid_count == 1` 移除时硬重置 `(0, 0, 0)`，`valid_count == 0` 加入时硬初始化 `(1, x, 0)`，切断 stale 残留。

### 离群值离开条件重算

Welford Remove 含减法，存在数值稳定性风险。当窗口中存在极端离群值（如 $x_{\text{out}} = 10^6$）而其余元素方差 ~1 时，离群值在窗期间 M2 ≈ 10¹²。float64 仅 15.9 位十进制精度，10¹² 量级下能分辨到 ~10⁻⁴，窗口内真实方差（~1 量级）的低位信息被截断丢弃。

离群值离开时 Remove 执行：

$$M2 \leftarrow M2 - \delta_{\text{out}} \cdot (x_{\text{out}} - \text{mean}_{\text{new}}) \approx 10^{12} - 10^{12} \;\Rightarrow\; \text{截断误差}$$

残余 M2 不再精确，可能为极小值甚至负数。触发条件：

$$\text{rescan if} \;\; M2_{\text{new}} < 0 \;\;\text{or}\;\; M2_{\text{new}} < 10^{-9} \cdot M2_{\text{old}}$$

M2 缩减 10⁹ 倍意味着 9 个有效数字被抵消，剩余精度仅 6-7 位，必然击穿 10⁻⁵ 容忍度。触发后对当前窗口 $[i-n+1, \, i-1]$ 执行 O(n) 单趟 Welford 重算：

```cpp
if (M2 < 0.0 || M2 < 1e-9 * old_M2) {
    size_t vc_r = 0; price_t mean_r = 0.0, M2_r = 0.0;
    size_t lo = i - static_cast<size_t>(n) + 1;
    for (size_t j = lo; j < i; ++j) {
        if (!std::isnan(src[j])) {
            vc_r++;
            if (vc_r == 1) { mean_r = src[j]; }
            else { price_t d = src[j] - mean_r; mean_r += d / vc_r; M2_r += d * (src[j] - mean_r); }
        }
    }
    valid_count = vc_r; mean = mean_r; M2 = M2_r;
}
```

n ≤ 250 时重算开销微乎其微（最多 250 次基础算术，极大概率在 L1/L2 缓存中），离群值离开是低频事件，摊还复杂度严格 O(1)。

### 窗口未满输出 NaN

`m_discard = data.discard() + n - 1`，`i < m_discard` 时输出 NaN（状态机照常累加但不写输出）。保持与序列对齐的 discard 契约，与 MA 原有 discard 语义一致。

### _dyn 路径

单趟全量 Welford（动态窗口左边界跳变，不维护 Remove 状态），同步加入 NaN 检查和 valid_count 逻辑。窗口未满 guard `if (curPos + 1 < ind.discard() + step) return` 提前退出（在 `_get_step_start` 之前，避免无用计算），`valid_count <= 1` 时不调用 `_set`（输出 NaN）。guard 保证 _dyn 路径 discard 与静态路径一致（均由 `updateDiscard` 扫描到 `data.discard() + step - 1`）。

### 关键设计决策

1. **MA 用 Welford 均值而非朴素 sum**：朴素 sum 长期滚动有随机游走漂移（约 $\sqrt{N} \cdot \varepsilon$），Welford 均值是阻尼平滑、锚定近期分布。若 MA 和 STDEV 用不同路径算均值，ICIR 分子分母将属于不同的统计系统。且 Welford 算 STDEV 时必然产出高精度 mean 作为副产物，再维护独立 sum 是冗余 + 第二误差源。大基数小方差场景下（如 $x_i = 10^8 + \epsilon_i$, $\epsilon_i \in [1, 10]$），Welford 的 $\delta = x - \text{mean} \approx \epsilon$ 在第一步无损消除大基数, $M2$ 只处理残差（量级 1 至 100），精度为 0。朴素 $\text{sum} \approx 2.5 \times 10^{10}$ 则因 float64 吸收效应产生截断漂移。

2. **valid_count/mean 更新逻辑字符级一致**：IMa 和 IStdev 是独立 C++ 类，无法共享状态对象，但两者的 `(valid_count, mean)` Add/Remove 更新序列对相同输入产出位级一致的 mean，ICIR 一致性由此保证。

3. **重算触发用 `M2 < 1e-9 * old_M2` 而非离群值占比**：精度坍塌不取决于离群值在方差中的百分比占比，而严格受限于浮点减法后有效数字的绝对损失量级。10^9 倍缩减 = 9 位有效数字被抵消 = 剩余 6-7 位精度。无需附加 `M2_old > 某量级` 防御（近零方差窗口跨 9 个数量级骤降是极端奇异点，偶发误触的 O(n) 重算是白噪声）。

4. **窗口未满输出 NaN（选项 X）**：保持 `m_discard = data.discard() + n - 1` 契约不破坏序列对齐。ICIR 语义是"过去 N 期 IC 的稳定度"，缺数据期不应参与，未满 N 期不应给值。

5. **n==0 保留 expand-all 语义**：n==0 是全量模式（`m_discard = data.discard()`，每个位置输出累计 std），与 n>0 的 rolling 语义不同但合理（全量均值本就是"所有可用值的均值"）。n==0 极少使用（ICIR 用 n>0）。

### 删除内容

- IStdev 的 `for (j = i-n; j < i; j++)` 扫描法（最坏 O(N·M) 退化）
- `pow_buf` O(N) 内存缓冲
- shifted-data 基准 `k`（Welford 本质即每步动态 shifted，大基数无损消除）
- IStdev 末尾的 `dst[0] = Null; m_discard += 1` 特殊处理（新方案 `valid_count <= 1` 时自然 NaN）

### 浮点噪声防御

输出标准差时加 `std::max(0.0, M2 / (valid_count - 1))` 截断：

$$\text{STDEV}_i = \sqrt{\max\!\left(0,\; \frac{M2_i}{\text{vc}_i - 1}\right)}$$

Welford Remove 含减法，极端浮点边界下 $M2$ 可能变为极微负值（如 $-10^{-16}$），`sqrt(负数)` 会产生 NaN。常数序列（Zero Variance）场景经测试验证: $M2$ 恒为精确 0.0，`max(0,...)` 防御确保输出 0.0 而非 NaN。

## 验证

### 编译

Windows 11 + MSVC + VS2022 + xmake，`xmake -b unit-test` 编译通过，仅 2 个既有 `utils.cpp` 符号/无符号 warning（与本次改动无关）。

### 功能验证

新增 19 个 NaN 语义测试用例，expected 值由独立 Welford 实现交叉验证：

| 用例 | 数据 | 验证点 |
|------|------|--------|
| 散布 NaN | `[1,2,3,NaN,5,6,7,8,9,10]` n=4 | i=3 窗口[1,2,3,NaN]→vc=3, MA=2.0, STD=1.0；i=6 NaN 离开后恢复 vc=3 |
| 连续 NaN 穿越 | `[1,2,NaN,NaN,NaN,3,4]` n=3 | i=4 全 NaN 窗口 vc=0→NaN；i=5 从 0 重建 vc=1；i=6 恢复 vc=2, STD=0.707107 |
| count=1 边界 | `[NaN,NaN,NaN,5,NaN,NaN,NaN]` n=4 | vc 恒=1，MA 输出 5.0，STD 安全返回 NaN（非 Inf/异常） |
| 大基数小方差 | `[1e8+1..1e8+5]` n=3 | Welford 无损消除大基数，MA=1e8+2, STD=1.0 精确 |
| 离群值离开重算 | `[10,10,10,1e6,2,4,4,4,5,5]` n=5 | i=8 离群值 1e6 离开，窗口[2,4,4,4,5]，STD=√1.2≈1.095445，误差 <1e-5 |
| 极小窗口 n=2 | `[3,NaN,5,7]` n=2 | i=2 窗口[NaN,5] vc=1→NaN；i=3 窗口[5,7] STD=1.414214 |
| n=1 参数拦截 | `[1..5]` n=1 | _checkParam 拦截（HKU_ASSERT n==0||n>=2），抛异常而非 Inf/崩溃 |
| 常数序列 Zero Variance | `[3.14,3.14,3.14,3.14,3.14]` n=3 | 浮点噪声可能让 M2 微负，max(0,...) 防御确保输出 0.0 而非 NaN |
| 全 NaN | `[NaN,NaN,NaN,NaN]` n=3 | 全程 NaN，不死循环不抛异常 |
| 上游 discard 传递 | discard=4, n=3 | 结果 discard=6，前 6 个全 NaN，i=6 窗口[5,6,7] STD=1.0 |
| _dyn 等价 | 含 NaN + CVAL 动态 n | common discard 后逐元素一致 |
| ICIR 一致性 | 含 NaN 的 MA/STDEV 组合 | 任一为 NaN 时 IR 静默 NaN，不抛除零异常 |
| ICIR count=1 | 单有效值 | std=NaN 时 IR 静默 NaN（不除零崩溃） |

**离群值重算精度验证**（Case 5 核心反例）：

| 位置 | 窗口 | 修复前（无重算） | 修复后（条件重算） | 精确值 |
|------|------|-----------------|-------------------|--------|
| i=8 | [2,4,4,4,5] | 1.095459（误差 1.4e-5） | 1.095445（误差 2.2e-16） | √1.2 ≈ 1.095445 |

修复前（`delta² > 0.99999 * old_M2` 触发条件）不触发重算，离群值占比 80% 不满足 99.999% 阈值，但精度已坍塌。修复后（`M2 < 1e-9 * old_M2`）M2 从 ~8e11 骤降到 3.0，比值 ~3.75e-12 < 1e-9，正确触发重算。

### 回归测试

| 项目 | 结果 |
|------|------|
| test_MA 现有用例 | 115/115 通过（干净数据 Welford 与原 sum 输出一致，discard 不变） |
| test_STDEV 现有用例 | 修改 expected（discard 1→9，位置 0-8 改 NaN，位置 9+ 保持原值） |
| **完整测试套件** | **719/719 通过，197072 assertions，0 失败 0 回归** |

```
[doctest] test cases:    719 |    719 passed | 0 failed | 0 skipped
[doctest] assertions: 197072 | 197072 passed | 0 failed |
[doctest] Status: SUCCESS!
```

## 改动范围

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/imp/IMa.cpp` | +76/-33：n<=0 分母改 valid_count，n>0 分支改 Welford 均值 `(vc, mean)`，_dyn 单趟 Welford + 窗口未满 guard |
| `hikyuu_cpp/hikyuu/indicator/imp/IStdev.cpp` | +186/-86：Welford 方差 `(vc, mean, M2)` + 条件重算 + max(0,...) 防御 + n==0 全量保留 + _dyn guard，删除扫描法/pow_buf/shifted-k |
| `hikyuu_cpp/unit_test/.../test_MA.cpp` | +209：9 个 NaN 用例（含 n=0+NaN 分母验证） |
| `hikyuu_cpp/unit_test/.../test_STDEV.cpp` | +243/-15：11 个 NaN 用例 + 回归 expected 修改 |
| `hikyuu_cpp/unit_test/.../test_ICIR_nan_consistency.cpp` | +76：新文件，2 个 ICIR 组合用例 |
| `hikyuu/draw/drawplot/echarts_draw.py` | +1/-1：STDEV(...,len) → STDEV(...,0) |
| `hikyuu/draw/drawplot/matplotlib_draw.py` | +1/-1：同上 |

合计 7 文件，+773/-134。不改任何 API 签名/返回类型。

## 性能影响

| 维度 | 旧实现 | 新实现 |
|------|--------|--------|
| 滚动每步复杂度 | MA O(1), STDEV O(N) 最坏（扫描法） | MA O(1), STDEV O(1) 摊还（重算低频触发） |
| 额外内存 | STDEV O(N) pow_buf | O(1)（消除 pow_buf） |
| 大基数小方差 | STDEV shifted-k 可缓解但 k 固定退化解 | Welford 每步动态 shifted，无损 |

干净数据下 Welford Add/Remove 与原 sum/scan 性能相当，无可见吞吐影响。

## BREAKING CHANGE

**STDEV discard 语义变更**：`m_discard` 从 `data.discard()`（+ 末尾 +1）改为 `data.discard() + n - 1`。窗口未满（i < n-1）不再输出累计标准差，统一输出 NaN。旧 STDEV 的 expand 模式（窗口未满输出累计值）与 MA（窗口未满输出 NaN）本就不一致，此变更纠正为一致的 rolling 语义。

### 下游影响与适配

STDEV discard 变更影响 5 处上游自身代码，经全量搜索确认：

| 下游 | 影响 | 处理 |
|------|------|------|
| `echarts_draw.py:554` / `matplotlib_draw.py:896` | `STDEV(ROCP(funds), len)` 用 n=len 表达全期 std，新实现 discard≥total → sigma 全 NaN → 夏普比率 nan | **本 PR 修复**：改为 `STDEV(..., 0)`（n=0 expand-all，`sigma[-1]` 与旧 n=len 严格等价） |
| `SingleSignal.cpp:53` / `SingleSignal2.cpp:56` | `dev.discard()` 作循环起点，后移 filter_n-1 个 bar，暖机段信号丢失 | **不改代码**：旧暖机段用 2~n-1 样本算 std 作阈值是统计学 bug，新行为强制窗口满后才输出是实质修复 |
| `kaufman.py:62-64` | `lstd.discard` 切片起点后移 n-1 个 bar | **不改代码**：Python 切片天然自适应，新行为是图形+统计双重纠正 |
| `IR.h:38` | `x / STDEV(x, n)`，n>0 时 IR 有效起点后移 n-2 个位置 | **不改代码**：rolling IR 窗口未满输出 NaN 是唯一正确语义，文档已建议 n=0 用于全期 IR |
| `ICIR.h` / `ICIRMultiFactor.cpp` / `MultiFactorBase.cpp` | MA/STDEV 组合 | **不受影响**：MA 分子 discard 一直是 `ic.discard()+n-1`，窗口未满区间 MA 为 NaN 屏蔽 STDEV 输出，变更前后 ICIR 可观测输出不变 |

### 对用户的可观测影响

上述 3 处"不改代码"的下游（SingleSignal/kaufman/IR）虽不崩溃，但**行为静默变更**：

- **SG_Single / SG_Single2 策略回测结果会变**：暖机段（窗口未满的前 n-2 个 bar）不再生成买卖信号。旧实现用 2~n-1 个样本的累计 std 作波动率阈值，产生的信号统计上不可靠（小样本 std 极不稳定），但用户之前的回测可能依赖了这些信号。新实现从窗口满（n 个样本）才开始，信号更可靠但交易次数可能减少。
- **kaufman 绘图**：自适应移动平均的包络带（fill_between）起点后移 n-1 个 bar，前端带形从"累计 std"变为缺失。
- **IR 指标**（n>0 模式）：有效起点后移 n-2 个位置。n=0 模式（文档推荐的全期 IR 用法）不受影响。

这些变更是 STDEV 语义纠正的必然结果（从 expand 模式对齐到 rolling 模式），旧暖机段行为在统计学上是缺陷。如需保留旧行为，用户可改用 `STDEV(x, 0)`（expand-all 语义）。

## 已知局限与后续工作

无。本 PR 修复了 MA/STDEV 的 NaN 语义不一致，_dyn 路径 discard 与静态路径已统一。n==0 为 Expanding Window（扩展窗口），与 n>0 的 Sliding Window（滑动窗口）是两种不同的统计算法模式，discard 语义差异是合理的，非局限。
