### PR TITLE
fix(ISumBars): 修复 _dyn_calculate 返回值符号与静态版相反

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/crt/SUMBARS.h
+++ b/hikyuu_cpp/hikyuu/indicator/crt/SUMBARS.h
@@ -22,6 +22,13 @@ namespace hku {
  * 用法：SUMBARS(X,A):将X向前累加直到大于等于A,返回这个区间的周期数
  * 例如：SUMBARS(VOL,CAPITAL)求完全换手到现在的周期数
  * </pre>
+ * @note discard 语义(标量参数 vs 序列参数存在差异):
+ *  - 标量参数 `SUMBARS(ind, double)`: 若某位累加到序列最左端仍 < a, 整段被标为 discard
+ *    (静态全局优化, 因标量 a 单调不可达时此前各位更不可达).
+ *  - 序列参数 `SUMBARS(ind, IndParam)`: 不可达位逐位写 NaN, 但不推进 discard
+ *    (动态 a 序列非单调, a[i] 不可达不代表 a[i+1] 不可达, 推进会抹杀后续可计算位).
+ *  即动态路径不保证"discard 之后全为有效数值". 下游应按 `std::isnan` 处理,
+ *  不应假设"discard 之后皆有效".
  * @ingroup Indicator
  */
 Indicator HKU_API SUMBARS(double a);

--- a/hikyuu_cpp/hikyuu/indicator/imp/ISumBars.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ISumBars.cpp
@@ -104,7 +104,7 @@ void ISumBars::_dyn_calculate(const Indicator& ind) {
         for (size_t j = i; j >= ind.discard(); j--) {
             sum += ind[j];
             if (sum >= a) {
-                n = price_t(j - i);
+                n = price_t(i - j);  // 与静态版 dst[i] = i - pos 一致（向前累加的周期数 >= 0）
                 break;
             }
             if (j == ind.discard()) {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_SUMBARS.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_SUMBARS.cpp
@@ -14,6 +14,7 @@
 #include <hikyuu/indicator/crt/SUMBARS.h>
 #include <hikyuu/indicator/crt/KDATA.h>
 #include <hikyuu/indicator/crt/PRICELIST.h>
+#include <hikyuu/indicator/crt/MA.h>
 
 using namespace hku;
 
@@ -195,6 +196,195 @@ TEST_CASE("test_SUMBARS_dyn") {
     for (size_t i = expect.discard(); i < expect.size(); i++) {
         CHECK_EQ(expect[i], doctest::Approx(result[i]));
     }
+}
+
+//-----------------------------------------------------------------------------
+// 动态/静态路径符号回归（修复 _dyn_calculate 返回负号的 bug）
+//-----------------------------------------------------------------------------
+/** @par 检测点 */
+TEST_CASE("test_SUMBARS_dyn_sign_regression") {
+    // 反例：末位需向左回溯 2 根才累加到 a，距离 > 0（非退化解）
+    //   修复前动态版返回 -2（符号错误），修复后返回 2（与静态版一致）
+    PriceList a;
+    a.push_back(5);
+    a.push_back(3);
+    a.push_back(2);  // [5, 3, 2]
+    Indicator data = PRICELIST(a);
+
+    // 静态路径（标量参数）
+    Indicator s = SUMBARS(data, 10);
+    CHECK_UNARY(std::isnan(s[0]));
+    CHECK_UNARY(std::isnan(s[1]));
+    CHECK_EQ(s[2], 2);  // i=2 向左回溯到 j=0, 距离 2
+
+    // 动态路径（IndParam 序列参数，常量序列）
+    Indicator d1 = SUMBARS(data, CVAL(data, 10));
+    CHECK_UNARY(std::isnan(d1[0]));
+    CHECK_UNARY(std::isnan(d1[1]));
+    CHECK_EQ(d1[2], 2);  // 修复前为 -2
+
+    Indicator d2 = SUMBARS(data, IndParam(CVAL(data, 10)));
+    CHECK_EQ(d2[2], 2);
+
+    // 动态/静态逐位数值对称（discard 不要求相等，见下用例）
+    CHECK_EQ(s.size(), d1.size());
+    for (size_t i = 0; i < s.size(); i++) {
+        if (std::isnan(s[i])) {
+            CHECK_UNARY(std::isnan(d1[i]));
+        } else {
+            CHECK_EQ(s[i], doctest::Approx(d1[i]));
+        }
+    }
+}
+
+/** @par 检测点 */
+TEST_CASE("test_SUMBARS_dyn_static_equivalence") {
+    // 多个位置的距离 > 0，覆盖非退化解等价类
+    PriceList a;
+    for (int i = 0; i < 10; i++) {
+        a.push_back(i * 10);  // [0,10,20,30,40,50,60,70,80,90]
+    }
+    Indicator data = PRICELIST(a);
+
+    // 静态: discard=4, [4]=2, [5..8]=1, [9]=0
+    Indicator s = SUMBARS(data, 90);
+    CHECK_EQ(s[4], 2);
+    CHECK_EQ(s[5], 1);
+    CHECK_EQ(s[6], 1);
+    CHECK_EQ(s[7], 1);
+    CHECK_EQ(s[8], 1);
+    CHECK_EQ(s[9], 0);
+
+    auto check_eq = [](const Indicator& x, const Indicator& y) {
+        CHECK_EQ(x.size(), y.size());
+        for (size_t i = 0; i < x.size(); i++) {
+            if (std::isnan(x[i])) {
+                CHECK_UNARY(std::isnan(y[i]));
+            } else {
+                CHECK_EQ(x[i], doctest::Approx(y[i]));
+            }
+        }
+    };
+
+    check_eq(s, SUMBARS(data, CVAL(data, 90)));
+    check_eq(s, SUMBARS(data, IndParam(CVAL(data, 90))));
+}
+
+/** @par 检测点 */
+TEST_CASE("test_SUMBARS_dyn_unreachable_discard") {
+    // 全段累加不可达：动态版仅逐位写 NaN 且不推进 discard，静态版整体丢弃
+    PriceList a;
+    for (int i = 0; i < 10; i++) {
+        a.push_back(1);  // 全 1
+    }
+    Indicator data = PRICELIST(a);
+
+    Indicator s = SUMBARS(data, 100);  // 全段不可达
+    CHECK_EQ(s.discard(), s.size());  // 静态版整体丢弃
+    for (size_t i = 0; i < s.size(); i++) {
+        CHECK_UNARY(std::isnan(s[i]));
+    }
+
+    Indicator d = SUMBARS(data, CVAL(data, 100));
+    CHECK_EQ(d.discard(), data.discard());  // 动态版不扩大 discard（== 输入 discard）
+    for (size_t i = 0; i < d.size(); i++) {
+        CHECK_UNARY(std::isnan(d[i]));
+    }
+}
+
+/** @par 检测点 */
+TEST_CASE("test_SUMBARS_dyn_edge") {
+    // 1. a <= 0：首根即 sum>=a 成立，距离恒为 0（验证 i==j 退化解，不死循环）
+    {
+        PriceList a;
+        for (int i = 0; i < 5; i++) a.push_back(i + 1);  // [1,2,3,4,5]
+        Indicator data = PRICELIST(a);
+
+        Indicator s0 = SUMBARS(data, 0);
+        Indicator d0 = SUMBARS(data, CVAL(data, 0));
+        for (size_t i = 0; i < data.size(); i++) {
+            CHECK_EQ(s0[i], 0);
+            CHECK_EQ(d0[i], 0);
+        }
+
+        Indicator sneg = SUMBARS(data, -5);
+        Indicator dneg = SUMBARS(data, CVAL(data, -5));
+        for (size_t i = 0; i < data.size(); i++) {
+            CHECK_EQ(sneg[i], 0);
+            CHECK_EQ(dneg[i], 0);
+        }
+    }
+
+    // 2. 输入序列带 discard > 0：内层 j 循环下界为 ind.discard()，验证终止不越界
+    {
+        PriceList a;
+        a.push_back(10);
+        for (int i = 0; i < 6; i++) a.push_back(1);  // [10,1,1,1,1,1,1]
+        Indicator ma = MA(PRICELIST(a), 2);  // discard=1, [1]=(10+1)/2=5.5, 之后恒为 1
+        CHECK_EQ(ma.discard(), 1);
+
+        Indicator s = SUMBARS(ma, 2);
+        Indicator d = SUMBARS(ma, CVAL(ma, 2));
+        CHECK_EQ(d.discard(), ma.discard());
+        CHECK_EQ(s[1], 0);  // j=1 sum=5.5>=2
+        CHECK_EQ(d[1], 0);
+        CHECK_EQ(s[2], 1);  // j=2 sum=1; j=1 sum=6.5>=2 -> i-j=1
+        CHECK_EQ(d[2], 1);
+        CHECK_EQ(s[3], 1);
+        CHECK_EQ(d[3], 1);
+    }
+
+    // 3. 极端长度
+    {
+        // 空序列：不崩溃
+        PriceList empty;
+        Indicator data = PRICELIST(empty);
+        Indicator s = SUMBARS(data, 10);
+        Indicator d = SUMBARS(data, CVAL(data, 10));
+        CHECK_EQ(s.size(), 0);
+        CHECK_EQ(d.size(), 0);
+
+        // 单根可达（静态路径可用 CVAL；动态路径用 PRICELIST 构造 size=1 的 a 序列，
+        // 规避 CVAL 嵌套在单元素上 size 传播为 0 的缺陷）
+        Indicator one = CVAL(10);
+        CHECK_EQ(SUMBARS(one, 10)[0], 0);
+        PriceList one_pl;
+        one_pl.push_back(10);
+        CHECK_EQ(SUMBARS(one, IndParam(PRICELIST(one_pl)))[0], 0);
+
+        // 单根不可达
+        CHECK_UNARY(std::isnan(SUMBARS(one, 20)[0]));
+        PriceList unreach_pl;
+        unreach_pl.push_back(20);
+        CHECK_UNARY(std::isnan(SUMBARS(one, IndParam(PRICELIST(unreach_pl)))[0]));
+    }
+}
+
+/** @par 检测点 */
+TEST_CASE("test_SUMBARS_dyn_varying_param") {
+    // 动态参数 a 序列逐位变化，手工核算
+    PriceList a;
+    a.push_back(1);
+    a.push_back(2);
+    a.push_back(3);
+    a.push_back(2);
+    a.push_back(1);  // data=[1,2,3,2,1]
+    Indicator data = PRICELIST(a);
+
+    PriceList pa;
+    pa.push_back(5);
+    pa.push_back(100);
+    pa.push_back(3);
+    pa.push_back(3);
+    pa.push_back(3);  // a=[5,100,3,3,3]
+    Indicator aseq = PRICELIST(pa);
+
+    Indicator d = SUMBARS(data, IndParam(aseq));
+    CHECK_UNARY(std::isnan(d[0]));  // a=5, 累加至 j=0 sum=1 <5
+    CHECK_UNARY(std::isnan(d[1]));  // a=100, 不可达
+    CHECK_EQ(d[2], 0);              // a=3, j=2 sum=3>=3
+    CHECK_EQ(d[3], 1);             // a=3, j=3 sum=2, j=2 sum=5>=3 -> i-j=1
+    CHECK_EQ(d[4], 1);              // a=3, j=4 sum=1, j=3 sum=3>=3 -> i-j=1
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## 问题概述

`SUMBARS` 的动态参数路径 `_dyn_calculate` 返回"向前累加的周期数"时符号与静态路径 `_calculate` 完全相反：静态版返回非负距离（`i - pos`），动态版返回非正距离（`j - i`）。只要动态传参调用 `SUMBARS` 且实际距离 > 0，结果即变为负数。

---

## 根因分析

`SUMBARS` 语义为"将 X 向前累加直到大于等于 A，返回这个区间的周期数"，距离必为非负。两条计算路径的赋值写法不一致：

```cpp
// 静态版 _calculate（正确，>= 0）
dst[i] = i - pos;   // pos 是回溯到的最早满足 sum>=a 的索引, pos <= i

// 动态版 _dyn_calculate（错误，<= 0）
for (size_t j = i; j >= ind.discard(); j--) {
    sum += ind[j];
    if (sum >= a) {
        n = price_t(j - i);   // j 从 i 递减, j <= i, 恒 <= 0
        break;
    }
}
```

`j` 是回溯游标，从 `i` 向左递减，`j - i` 恒 <= 0；而静态版 `i - pos`（`pos` 即 `j`）恒 >= 0。同一个指标仅因参数传递方式（标量 vs 序列）不同，返回值正负号相反。

反例：`ind = [5, 3, 2]`（末位 i=2），`a = 10`，需向左回溯 2 根（j=2 sum=2, j=1 sum=5, j=0 sum=10 >=10）：

| 路径 | 表达式 | 结果 |
|------|--------|------|
| 静态版 | `i - pos = 2 - 0` | 2 |
| 动态版（修复前） | `j - i = 0 - 2` | -2 |
| 动态版（修复后） | `i - j = 2 - 0` | 2 |

---

## 修复方案

将动态版赋值改为 `n = price_t(i - j)`，与静态版 `dst[i] = i - pos` 严格同构。单行改动，无其他游标逻辑需同步。

```diff
         for (size_t j = i; j >= ind.discard(); j--) {
             sum += ind[j];
             if (sum >= a) {
-                n = price_t(j - i);
+                n = price_t(i - j);  // 与静态版 dst[i] = i - pos 一致（向前累加的周期数 >= 0）
                 break;
             }
```

### 关键设计决策

1. **仅改符号，不动 discard 逻辑**：动态版在全段不可达时仅逐位写 NaN、不推进全局 `m_discard`；静态版会把整体 `m_discard` 推到 `last_pos+1`。此差异**有意保留**——动态参数 `a` 是序列、非单调，`a[i]` 不可达不代表 `a[i+1]` 不可达，强行推进 `m_discard` 会抹杀后续可计算的有效位。既有测试 `test_SUMBARS_dyn` 中 `// CHECK_EQ(expect.discard(), result.discard());` 已被注释，印证此差异已知且刻意保留。

---

## 验证

### 编译

- MSVC 2022 + xmake，release 构建，编译通过（仅 2 个 utils.cpp 既有 warning，与本次改动无关）。

### 功能验证

新增 5 个 doctest 用例覆盖符号回归、等价类、discard 不变式与边界：

| 用例 | 数据 | 修复前值 | 修复后值 | 验证点 |
|------|------|----------|----------|--------|
| `test_SUMBARS_dyn_sign_regression` | `[5,3,2]`, a=10 | 动态 d[2]=-2 | d[2]=2 | 距离>0 非退化解的符号回归（核心反例） |
| `test_SUMBARS_dyn_static_equivalence` | `[0..90]`, a=90 | 多位负数 | s==d 逐位相等 | 距离>0 等价类的动态/静态对称 |
| `test_SUMBARS_dyn_unreachable_discard` | 全 1, a=100 | — | 静态 discard==size, 动态 discard==输入 discard | 锁死"动态不可达不扩大 discard"不变式 |
| `test_SUMBARS_dyn_edge` | a<=0 / 输入带 discard / 极端长度 | — | 0 / 正确距离 / 不崩溃 | 退化解不死循环、j 下界终止不越界、空与单根 |
| `test_SUMBARS_dyn_varying_param` | data=`[1,2,3,2,1]`, a=`[5,100,3,3,3]` | — | `[NaN,NaN,0,1,1]` | 动态参数逐位变化手算核对 |

核心反例断言（锁定符号）：
```cpp
// [5,3,2], a=10：i=2 向左回溯到 j=0, 距离 2
Indicator s = SUMBARS(data, 10);
CHECK_EQ(s[2], 2);                              // 静态版
CHECK_EQ(SUMBARS(data, CVAL(data, 10))[2], 2);  // 动态版, 修复前为 -2
```

`test_SUMBARS_dyn_edge` 单根动态路径用 `PRICELIST` 构造 size=1 的 `a` 序列（`IndParam(PRICELIST(one_pl))`），规避 `CVAL` 嵌套在单元素上 size 传播为 0 的缺陷（该缺陷属 `CVAL` 上下文推导问题，与本 PR 无关，不在此展开）。

### 回归测试

- SUMBARS 相关：8 用例全部通过（含原有 3 + 新增 5），323 断言全绿。
- **完整测试套件：724 用例全部通过，0 失败，0 回归**（197172 断言全绿）。

---

## 改动范围

3 文件，`+198 / -1` 行：

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/imp/ISumBars.cpp` | 第 107 行 `j - i` → `i - j`（1 行） |
| `hikyuu_cpp/hikyuu/indicator/crt/SUMBARS.h` | 文档注释新增 discard 契约说明（9 行） |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_SUMBARS.cpp` | 追加 5 用例 + `MA.h` 头（190 行） |

- 不改任何 API 签名 / 返回类型，外部无感知。
- 不改 `_calculate`（静态版本就正确），仅修被委托的 `_dyn_calculate`。

---

## 性能影响

- 无。仅修正赋值表达式的变量顺序，无循环结构或复杂度变化。

---

## 本 PR 范围说明

两处与本 bug 相邻、经排查后**不在本 PR 修复范围**的现象，说明以划清边界：

### 动态/静态 discard 语义差异（有意设计，本 PR 补文档契约）

- 现象：动态版 `_dyn_calculate` 不可达时逐位写 NaN、不推进 `m_discard`；静态版 `_calculate` 整体推进 `m_discard`。这是 master 既有设计（`test_SUMBARS_dyn` 中 discard 相等断言已被原作者注释）。
- 为何有意保留：动态参数 `a` 是序列、非单调，`a[i]` 不可达不代表 `a[i+1]` 不可达；照搬静态版的全局推进优化会抹杀后续可计算的有效位。
- 为何无隐患：经全仓排查，SUMBARS 在 C++ 内无下游算子组合（仅 Python 导出供用户使用）；hikyuu buffer 默认 NaN、`get(i)` 返回 NaN 而非未定义值（"i < discard ⇒ NaN"为不变式）；下游 isnan 防御型（IDma/IMa 等）正确跳过、discard 前缀型（binary 算术/signal）把 NaN 原样传播或靠 NaN 比较恒 false 不误发信号，无静默数值传错路径。
- 本 PR 动作：在 `SUMBARS.h` 文档注释中新增 discard 契约说明，明确"动态路径不保证 discard 之后全为有效数值，下游应按 isnan 处理"。

### `CVAL` 嵌套单元素 size=0 缺陷（独立 PR 修复）

- 现象：`CVAL(CVAL(10), 10)` 的 size 推导为 0 而非 1，触发 `_dyn_calculate` 的 `HKU_CHECK(ind_param.size()==ind.size())` 异常。
- 根因：`Indicator::operator()` 的 alike 短路返回未计算的克隆空壳，与 SUMBARS 符号 bug 无关。
- 本 PR 处理：测试中改用 `PRICELIST` 规避该缺陷，不触及根因。
- 后续：已独立开 PR #487（`fix/cval-nested-size0-pr`）在 `Indicator.cpp` 层修复。