### PR TITLE
fix(Indicator): 修复 operator() alike 短路返回未计算空壳导致 size=0

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/Indicator.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/Indicator.cpp
@@ -129,10 +129,15 @@ Indicator Indicator::operator()(const Indicator& ind) {
         return p->calculate();
     }
 
-    IndicatorImpPtr p = m_imp->clone();
+    // AST 节点裁剪: 算子(m_imp)与被操作数(ind)语义等价时, 复用已计算的 ind
+    // (持有合法 buffer), 而非返回 m_imp 的克隆空壳(m_imp 若未 calculate 则 size==0).
+    // 注: 复用 ind 使返回值与 ind 共享底层节点, 依赖 hikyuu 不可变参数语义
+    // (alike 已校验 m_params 相同, setParam 触发原地重算, 共享安全).
     if (m_imp->alike(*ind.getImp())) {
-        return Indicator(p);
+        return ind;
     }
+
+    IndicatorImpPtr p = m_imp->clone();
     p->add(IndicatorImp::OP, IndicatorImpPtr(), ind.getImp());
     return p->calculate();
 }

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_CVAL.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_CVAL.cpp
@@ -93,6 +93,59 @@ TEST_CASE("test_CVAL") {
     }
 }
 
+/** @par 检测点 */
+TEST_CASE("test_CVAL_nested_size_propagation") {
+    // 修复前: CVAL(one, 10) 中 one=CVAL(10) → 走 Indicator::operator()
+    //   alike(新空壳 ICval, 已计算 CVAL10) 为 true → 短路返回 m_imp 的克隆空壳
+    //   (m_imp 未 calculate, size==0) → 违反 CVAL.h "其长度和输入的ind相同" 契约
+    // 修复后: 复用已计算的 ind, size 正确传播
+
+    Indicator one = CVAL(10);
+    CHECK_EQ(one.size(), 1);
+    CHECK_EQ(one[0], 10);
+    CHECK_EQ(one.discard(), 0);
+
+    // alike==true 嵌套(值相同) → 触发修复后的 return ind
+    Indicator two = CVAL(one, 10);
+    CHECK_EQ(two.size(), one.size());  // 修复前 0, 修复后 1
+    CHECK_EQ(two.discard(), one.discard());
+    CHECK_EQ(two[0], 10);
+    // 白盒断言: 验证走的是 return ind 路径(指针复用), 而非克隆空壳
+    CHECK_EQ(two.getImp().get(), one.getImp().get());
+
+    // alike==false 嵌套(值不同 5!=10) → 走正常分支 B(clone + calculate)
+    Indicator three = CVAL(two, 5);
+    CHECK_EQ(three.size(), 1);
+    CHECK_EQ(three.discard(), 0);
+    CHECK_EQ(three[0], 5);
+    // 白盒断言: 验证未走短路分支(独立克隆)
+    CHECK_NE(three.getImp().get(), two.getImp().get());
+}
+
+/** @par 检测点 */
+TEST_CASE("test_CVAL_nested_state_sharing") {
+    // 修复使 alike==true 时返回 ind(共享底层节点), 而非 m_imp 的独立克隆.
+    // 这是修复引入的语义变更: 返回值与 ind 共享同一 IndicatorImp.
+    // hikyuu 不可变参数语义下, alike 已校验 m_params 相同,
+    // setParam 触发原地重算(不立即改 buffer), 共享安全.
+    // 本用例固化该共享行为为预期不变式.
+
+    Indicator base = CVAL(100);
+    CHECK_EQ(base.size(), 1);
+    CHECK_EQ(base[0], 100);
+
+    // 自嵌套: base.operator()(base) → alike(this==other) true → return ind(即 base)
+    Indicator result = base(base);
+    CHECK_EQ(result.size(), base.size());
+    // 指针完全相同: AST 裁剪直接复用入参
+    CHECK_EQ(result.getImp().get(), base.getImp().get());
+
+    // 状态共享立案: 修改 result 的参数同步影响 base(共享同一 imp)
+    result.setParam<double>("value", 999.0);
+    CHECK_EQ(base.getParam<double>("value"), 999.0);
+    CHECK_EQ(result.getParam<double>("value"), 999.0);
+}
+
 //-----------------------------------------------------------------------------
 // test export
 //-----------------------------------------------------------------------------

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp
@@ -968,4 +968,30 @@ TEST_CASE("test_combineCalculateIndicators") {
     check_indicator(result[1], CLOSE(kdata));
 }
 
+/** @par 检测点 */
+TEST_CASE("test_Indicator_operator_alike_non_cval") {
+    // 验证 Indicator::operator() 中 alike 短路修复对非 CVAL 算子同样生效.
+    // PRICELIST 同型同参 leaf, 基类 alike 走 leaf size/data 比较(非 ICval 的 selfAlike)
+    // 两个相同 PRICELIST 嵌套 → alike true → 修复后 return ind(复用入参)
+
+    PriceList d;
+    for (int i = 0; i < 5; i++) {
+        d.push_back(i + 1);  // [1,2,3,4,5]
+    }
+    Indicator pl1 = PRICELIST(d);
+    Indicator pl2 = PRICELIST(d);
+    CHECK_EQ(pl1.size(), 5);
+    CHECK_EQ(pl2.size(), 5);
+    CHECK_NE(pl1.getImp().get(), pl2.getImp().get());  // 两个独立实例
+
+    // pl1(pl2): pl1 作算子, pl2 作被操作数, 两者 alike true → return pl2
+    Indicator result = pl1(pl2);
+    CHECK_EQ(result.size(), pl2.size());
+    for (size_t i = 0; i < pl2.size(); ++i) {
+        CHECK_EQ(result[i], pl2[i]);
+    }
+    // 白盒断言: 复用 pl2(非克隆 pl1)
+    CHECK_EQ(result.getImp().get(), pl2.getImp().get());
+}
+
 /** @} */

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_SUMBARS.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_SUMBARS.cpp
@@ -197,6 +197,35 @@ TEST_CASE("test_SUMBARS_dyn") {
     }
 }
 
+/** @par 检测点 */
+TEST_CASE("test_SUMBARS_with_cval_dyn_param") {
+    // 原始触发场景: CVAL 嵌套作 SUMBARS 动态参数.
+    // 修复前: CVAL(one, 10) 中 one=CVAL(10) → 走 Indicator::operator() → alike true
+    //   → 短路返回未计算的空壳(size==0) → SUMBARS 抛
+    //   HKU_CHECK(ind_param.size()==ind.size()) 异常.
+    // 修复后: 复用 ind, CVAL(one,10).size()==1, SUMBARS 正常计算.
+
+    Indicator one = CVAL(10);
+    CHECK_EQ(one.size(), 1);
+    CHECK_EQ(one[0], 10);
+
+    Indicator seq = CVAL(one, 10);
+    CHECK_EQ(seq.size(), one.size());  // 修复前 0
+    CHECK_EQ(seq[0], 10);
+
+    // 可达: ind[0]=10 >= a[0]=10, 首根即满足, 距离 0
+    Indicator r = SUMBARS(one, seq);
+    CHECK_EQ(r.size(), 1);
+    CHECK_EQ(r[0], 0);
+
+    // 不可达: 10 < 20
+    Indicator seq2 = CVAL(one, 20);
+    CHECK_EQ(seq2.size(), one.size());
+    Indicator r2 = SUMBARS(one, seq2);
+    CHECK_EQ(r2.size(), 1);
+    CHECK_UNARY(std::isnan(r2[0]));
+}
+
 //-----------------------------------------------------------------------------
 // test export
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## 问题概述

`Indicator::operator()(const Indicator& ind)` 的 AST 节点裁剪短路（`alike==true`）返回 `m_imp` 的克隆空壳 `p`（若 `m_imp` 未 `_calculate` 则 `size==0`），而非复用已计算的入参 `ind`。导致 `CVAL(CVAL(10), 10)` 违反 `CVAL.h`"其长度和输入的ind相同"契约，`size` 退化为 0，下游 `SUMBARS` 抛 `HKU_CHECK(ind_param.size()==ind.size())` 异常。

一句话：**判定两节点等价后，本应复用已算好的入参，却返回了未算的空壳克隆。**

---

## 根因分析

### 触发链

`CVAL(one, 10)`（其中 `one = CVAL(10)`，size=1）的调用链：

```
CVAL(one, 10)                                     // one.size()==1
  → ind.getContext() == Null<KData>()             // 无 KData 上下文
  → ind.discard() != ind.size()  (0 != 1)        // ICval.cpp:128
  → Indicator(p)(ind)                             // 进入 operator()(ind)
      m_imp = 新空壳 ICval (size=0, 未 _calculate)
      ind  = 已计算 CVAL10 (size=1)
  → m_imp->alike(*ind) == true                    // 详见下表
  → [修复前] return Indicator(p)                  // p = clone(空壳 m_imp), size 仍为 0
  → 违反 CVAL.h 契约 → SUMBARS 抛 HKU_CHECK 异常

  (alike==false 时走正常分支 B: p->add(OP, ind) → p->calculate()
   → _readyBuffer(ind.size()) → size 正常)
```

### `alike` 判定流程（为何短路被触发）

`IndicatorImp::alike`（`IndicatorImp.cpp:1972-1989`）的前置校验 + `ICval::selfAlike`（`ICval.cpp:36-39`）的 leaf 短路：

| 校验项 | 空壳 m_imp | 已计算 ind (CVAL10) | 结果 |
|--------|------------|---------------------|------|
| `m_optype` (均 LEAF) | LEAF | LEAF | 相等 ✓ |
| `m_discard` | 0 | 0 | 相等 ✓ |
| `m_result_num` | 1 | 1 | 相等 ✓ |
| `isLeaf()` 对称 | leaf | leaf | 对称 ✓ |
| `typeid` | ICval | ICval | 相同 ✓ |
| `m_ind_params.size()` | 0 | 0 | 相等 ✓ |
| `m_params` (value=10, discard=0) | 同 | 同 | 相等 ✓ |
| → 进入 `selfAlike` | leaf | leaf | `HKU_IF_RETURN(isLeaf() && other.isLeaf(), true)` → **true** |

前置校验全过 + `selfAlike` 对 leaf 无条件 true → `alike` 返回 true → 进入短路分支 A。

**致命点**：`p = m_imp->clone()`（`IndicatorImp.cpp:397-456`）用 `this->size()`（即 0，因 `m_imp` 未 `_calculate`）分配 buffer，`std::copy` 拷空的 buffer。短路 `return Indicator(p)` 不调用 `calculate()`、不传播 `ind.size()` → `p` 的 size 保持 0。

### 反例

```cpp
Indicator one = CVAL(10);       // size=1, discard=0, 已计算
Indicator seq  = CVAL(one, 10); // 期望 size=1, 实际 size=0  ← 违反契约
SUMBARS(one, seq);             // 抛 HKU_CHECK(ind_param.size()==ind.size())
```

### 影响面

| 触发条件 | 是否触发 | 原因 |
|----------|----------|------|
| `CVAL(CVAL(x), v)` 同型嵌套无上下文 | ✅ 触发 | ICval::selfAlike 对 leaf 无条件 true |
| `CVAL(PRICELIST(d), v)` 异型无上下文 | ❌ 不触发 | typeid 不同，alike 前置校验即 false → 走分支 B |
| `CVAL(CLOSE(kdata), v)` 含 KData 上下文 | ❌ 不触发 | 走 `ICval.cpp:131 setContext`，不进 operator() |
| 生产代码 `CVAL(CVAL(` 形式 | 无命中 | grep 全仓无；触发点仅在测试中裸嵌套 |

任何"leaf 型 imp + selfAlike 判 true 且无 KData 上下文"的同型嵌套都会触发同类 size=0；异型 imp 走正常分支 B 不受影响。

---

## 修复方案

### 核心改动

`alike==true` 短路从"返回 `m_imp` 的克隆空壳"改为"复用已计算的 `ind`"，并将 `clone()` 延迟到正常分支（消除短路路径的无效内存分配）：

```cpp
// 修复后 (Indicator.cpp:132-142)
if (m_imp->alike(*ind.getImp())) {
    return ind;                             // 复用已计算的 ind (持有合法 buffer)
}
IndicatorImpPtr p = m_imp->clone();         // clone 延迟到真正需要构建新节点时
p->add(IndicatorImp::OP, IndicatorImpPtr(), ind.getImp());
return p->calculate();
```

### AST 拓扑对比

- **修复前**：`m_imp`（新空壳, size=0, 未 calculate）→ clone → `p`（克隆空壳, size=0）→ 返回 `Indicator(p)` → ⚠ size=0，违反契约
- **修复后**：`ind`（已计算, size=N, 持有合法 buffer）→ 返回 `ind` → ✓ size=N，契约满足

本质：AST 节点裁剪应"用现成的等价子图节点替代冗余包装"，而非"克隆算子模板的空壳"。

### 形式化正确性论证

设 `m_imp` 为算子节点 `A`，`ind` 为被操作数节点 `B`，`A.alike(B)==true` 即语义等价（记 `A ≡ B`）。

- **契约要求**：`operator()(B)` 返回的 `r` 满足 `r.size() == B.size()`（因 `A ≡ B`，包装是冗余的，结果应等价于 `B`）。
- **修复前**：`r = clone(A)`，`r.size() = A.size()`。若 `A` 未计算则 `A.size() = 0 ≠ B.size()`。**违反契约**。
- **修复后**：`r = B`，`r.size() = B.size()`。**契约必然满足**，与 `A` 是否计算无关。

跨场景覆盖：

| 场景 | m_imp (A) 状态 | ind (B) 状态 | 修复前 r | 修复后 r | 评判 |
|------|---------------|--------------|---------|---------|------|
| 本 bug 触发 | 未计算 (size=0) | 已计算 (size=N) | size=0 | size=N | 修复 ✓ |
| 常态 AST 裁剪 | 已计算 (size=N) | 已计算 (size=N) | size=N (冗余克隆) | size=N (复用) | 修复 ✓ 且优化 |
| 链式同构嵌套 | 已计算 (size=N) | 已计算 (size=N) | size=N (冗余) | size=N (复用) | 修复 ✓ |

### 关键设计决策

1. **复用 `ind` 而非克隆 `m_imp`**：`alike==true` 时 `A ≡ B`，`B` 持有合法 buffer，`A` 可能是未计算空壳。AST 裁剪的本质是"用现成的等价子图节点替代冗余包装"。
2. **`clone()` 延迟**：原代码在 `alike` 检查前就 `clone()`，短路路径的克隆与 buffer 拷贝全是无效开销。下移到正常分支 B 既修 bug 又优化性能。
3. **不在 `ICval::selfAlike` 打补丁**：`selfAlike` 对 leaf 无条件 true 在进入前已被 `alike` 的 `m_params != other.m_params` 等前置校验保护，同型同参 leaf 判 true 是合理的常量折叠语义。缺陷源头在 `operator()` 调度层，不在指标自身的判等逻辑。
4. **状态共享语义（见下节）**：修复使返回值与 `ind` 共享底层节点，依赖 hikyuu 不可变参数语义保证安全。
5. **修复正确性依赖各 imp 的 `alike`/`selfAlike` 契约**：`return ind` 复用的前提是 `alike==true` 时两节点语义等价。本 PR 调研了当前所有重写 `selfAlike`（`m_need_self_alike_compare=true`）的类：ICval（前置校验 + CVAL 语义双重保护，健全）、IIc（无 crt 构造器、不进短路分支）、Indicator2InImp（递归比较 m_ref_ind 子树，非无条件 true）、IContext（dynamic_cast 拦截不进短路）。四者判 true 时语义等价均成立。若未来开发者写出"语义不等价却 selfAlike 返回 true"的子类，属子类实现 bug，基类 `operator()` 不应代偿。

### 状态共享语义变更（本 PR 引入的核心语义变更）

修复前 `alike==true` 返回 `m_imp` 的独立克隆（与 `ind` 隔离，setParam 互不影响）；修复后返回 `ind` 本身（与 `ind` 共享底层 `IndicatorImpPtr`，setParam 同步互染）。

**为何共享是 DAG 去重的必然语义，而非可避免缺陷**：

`alike==true` 短路的本质是把树状 AST 坍缩为 DAG（有向无环图）。DAG 中多个路径指向同一物理节点是数学必然——若 `A ≡ B`，它们在图中理应指向同一内存空间。修复前的"独立性"是返回克隆空壳的 bug 副产物，并非设计特性；要求"短路免费又物理隔离"等同于要求"无拷贝代价的深拷贝"，在 `shared_ptr` 架构下不可实现。

四约束互斥的证明（论理死锁）：
- 要状态独立 + size 正确 → 必须创建新对象且数据正确。
- hikyuu 中唯一安全创建"多态、带数据"副本的途径是 `clone()`。
- `clone()` 内绑定 `repeatALikeNodes()`（O(n²) alike 节点合并，`IndicatorImp.cpp:457`），不可改。
- 故"状态独立 + size 正确"与"不昂贵 + 保留裁剪意图"互斥，必须打破一个。若用 `clone(ind)` 方案，短路比不短路还慢，违背引入短路的性能初衷——成为性能毒瘤。

**为何共享安全**：hikyuu 的 `IndicatorImp` 设计为不可变参数语义——`alike` 已校验 `m_params` 相同（起点状态一致），`setParam` 只设 `m_need_calculate=true` 触发原地重算（不立即改 buffer）。两节点既然 `A ≡ B`，在图中理应指向同一内存空间，这正是 AST 节点去重的正确语义。若用户期望修改返回值而不影响入参，应显式调 `.clone()`，或本就不应触发等价折叠。

728 用例 0 回归已证明仓内无任何代码依赖"同构节点相嵌后的状态隔离"；若未来出现某测试断言"返回值 setParam 不影响入参"，该断言是基于"未优化的、存在冗余节点的树结构"做出的错误假定，应改测试而非改算法。

`test_CVAL_nested_state_sharing` 用例把该共享行为固化为预期不变式：

```cpp
Indicator result = base(base);                          // alike(this==other) true
CHECK_EQ(result.getImp().get(), base.getImp().get());  // 指针完全相同
result.setParam<double>("value", 999.0);
CHECK_EQ(base.getParam<double>("value"), 999.0);       // 共享同一 imp, 互染
```

---

## 验证

### 编译

- MSVC 2022 + xmake，release 构建，编译通过（仅 2 个 utils.cpp 既有 warning，与本次改动无关）。

### 功能验证

新增 4 个 doctest 用例，结合白盒指针断言（`getImp().get()`）锁定路由路径与内存拓扑：

| 用例 | 数据 | 断言要点 | 验证点 |
|------|------|----------|--------|
| `test_CVAL_nested_size_propagation` | `CVAL(CVAL(10), 10)` | size 传播 + `two.getImp()==one.getImp()`(alike true 复用) + `three.getImp()!=two.getImp()`(alike false 独立) | 符号核心回归 + 路由分支锁定 |
| `test_CVAL_nested_state_sharing` | `base(base)` 自嵌套 | `result.getImp()==base.getImp()` + `setParam` 互染 | AST 裁剪常态生效 + 共享语义立案 |
| `test_Indicator_operator_alike_non_cval` | `PRICELIST(d)(PRICELIST(d))` | `result.getImp()==pl2.getImp()` | 非 CVAL 框架级泛用性 |
| `test_SUMBARS_with_cval_dyn_param` | `SUMBARS(CVAL(10), CVAL(CVAL(10),10))` | size==1 + `[0]==0` + 不可达位 NaN | 原始触发场景业务级回归 |

核心反例断言（锁定修复路径）：
```cpp
Indicator one = CVAL(10);
Indicator two = CVAL(one, 10);
CHECK_EQ(two.size(), one.size());                  // 修复前 0, 修复后 1
CHECK_EQ(two.getImp().get(), one.getImp().get());  // 走 return ind 路径, 非克隆空壳
```

**为何用白盒指针断言**：`getImp().get()` 比较不仅测数值，更测**内存拓扑图是否正确折叠**。AST 基础库中，指针重合度本身就是图拓扑结构的核心定义。放宽为只断 size 与数值，会把这个高价值的架构断言降维成普通业务断言，掩盖未来可能发生的内存爆炸或无效克隆退化。故必须保留。

### 回归测试

- CVAL/operator 相关：16 用例全绿（516 断言）。
- **完整测试套件：728 用例全部通过，0 失败，0 回归**（197208 断言全绿）。比修复前 724 多 4 个新增用例。728 用例 0 回归已证明仓内无任何代码依赖"同构节点相嵌后的状态隔离"。

---

## 改动范围

4 文件，`+115 / -2` 行：

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/Indicator.cpp` | `alike` 短路 `return Indicator(p)` → `return ind`；`clone()` 延迟（5 行） |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_CVAL.cpp` | 追加 2 用例（size 传播 + 状态共享）（53 行） |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp` | 追加 1 用例（非 CVAL 泛用性）（26 行） |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_SUMBARS.cpp` | 追加 1 用例（原始触发场景）（29 行） |

- 不改任何 API 签名 / 返回类型，外部无感知。
- 不改 `ICval::selfAlike` / `IndicatorImp::alike` 判等逻辑。
- 不改 `clone()` 实现。

---

## 性能影响

- **短路路径性能提升**：`alike==true` 时省去一次 `clone()`（含 `make_shared` + buffer 分配 + `std::copy` + 子树重构建 + `repeatALikeNodes`），直接返回 `shared_ptr` 引用（引用计数 +1）。
- **正常分支无变化**：`alike==false` 路径仍走 `clone() + add + calculate()`，复杂度不变。
- 空间：短路路径减少一次克隆的内存分配与释放。