### PR TITLE
fix(indicator): 修复 SPEARMAN(n=0) 默认参数不产出有效结果

### DIFF
--- a/hikyuu_cpp/hikyuu/indicator/imp/ISpearman.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/ISpearman.cpp
@@ -99,6 +99,11 @@ void ISpearman::_increment_calculate(const Indicator &ind, size_t start_pos) {
     Indicator ref = prepare(ind);
 
     int n = getParam<int>("n");
+    // 与 _calculate 一致：n=0 表示全窗口。_calculate 只把归一化后的 n 用于
+    // m_discard，再委托本函数；本函数重新 getParam 会读到原始 0，必须再次转换。
+    if (n == 0) {
+        n = total;
+    }
     auto *dst = this->data();
     auto const *srca = ind.data() + 1 - n;
     auto const *srcb = ref.data() + 1 - n;

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_SPEARMAN.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_SPEARMAN.cpp
@@ -176,6 +176,56 @@ TEST_CASE("test_SPEARMAN") {
 }
 
 /** @par 检测点 */
+TEST_CASE("test_SPEARMAN_n0_full_window") {
+    // 回归 n=0 默认参数：_calculate 将 n 归一化为 total 后委托
+    // _increment_calculate，后者必须再次归一化，否则窗口长度为 0、全 NaN。
+
+    /** @arg n=0 等价于 n=total 全窗口 */
+    PriceList a{3., 8., 4., 7., 2.};
+    PriceList b{5., 10., 8., 10., 6.};
+    Indicator x = PRICELIST(a);
+    Indicator y = PRICELIST(b);
+    Indicator result = SPEARMAN(x, y, 0);
+    CHECK_EQ(result.name(), "SPEARMAN");
+    CHECK_EQ(result.size(), a.size());
+    CHECK_EQ(result.discard(), 4);
+    // 硬编码期望钉死修复前“全 NaN”退路；并与显式 n=total 对照
+    CHECK_EQ(result[4], doctest::Approx(0.872082));
+    Indicator full = SPEARMAN(x, y, static_cast<int>(a.size()));
+    CHECK_EQ(result.discard(), full.discard());
+    CHECK_EQ(result[4], doctest::Approx(full[4]));
+
+    /** @arg 空序列 n=0：应安全返回空指标，不越界 */
+    result = SPEARMAN(Indicator(), Indicator(), 0);
+    CHECK_UNARY(result.empty());
+
+    /** @arg 极短序列 total=1, n=0：归一化 n=1，m_discard=0+1-1=0；
+     *  act_count=1<2 不写值，result[0] 为 NaN（discard 仍为 0，非全量） */
+    PriceList short_a{1.};
+    PriceList short_b{2.};
+    result = SPEARMAN(PRICELIST(short_a), PRICELIST(short_b), 0);
+    CHECK_EQ(result.size(), 1);
+    CHECK_EQ(result.discard(), 0);
+    CHECK_UNARY(std::isnan(result[0]));
+
+    /** @arg 下界触发 total=2, n=0：归一化 n=2，恰好 act_count==2，完全负相关 */
+    PriceList edge_a{1., 2.};
+    PriceList edge_b{2., 1.};
+    result = SPEARMAN(PRICELIST(edge_a), PRICELIST(edge_b), 0);
+    CHECK_EQ(result.size(), 2);
+    CHECK_EQ(result.discard(), 1);
+    CHECK_EQ(result[1], doctest::Approx(-1.0));
+
+    /** @arg 输入带 discard：有效数据不足以填满全窗口时 discard=total */
+    // total=5, ind.discard=2 → m_discard = 2 + 5 - 1 = 6 > 5 → discard=5
+    PriceList da{1., 2., 3., 4., 5.};
+    PriceList db{5., 4., 3., 2., 1.};
+    result = SPEARMAN(PRICELIST(da, 2), PRICELIST(db, 2), 0);
+    CHECK_EQ(result.size(), 5);
+    CHECK_EQ(result.discard(), 5);
+}
+
+/** @par 检测点 */
 TEST_CASE("test_SPEARMAN_with_ties") {
     // 回归 tie-handling: 当输入存在相同值(average-rank)时, 简化公式
     // 1 - 6*sum_d2/(n^3-n) 不再精确, 必须用 Pearson-on-ranks 计算。


### PR DESCRIPTION
## 问题概述

`SPEARMAN` 允许 `n=0`（语义为全窗口），构造函数默认也是 `n=0`。但 `_calculate` 将 `n=0` 归一化为 `total` 后把全部计算委托给 `_increment_calculate`，后者重新 `getParam("n")` 读到原始 `0`，窗口长度为 0，循环不执行，结果全为 NaN。默认参数路径静默失效。

## 根因分析

```cpp
// _calculate：本地归一化，只用于 m_discard
int n = getParam<int>("n");
if (n == 0) {
    n = total;
}
m_discard = std::max(ind.discard(), ref.discard()) + n - 1;
_increment_calculate(ind, m_discard);  // 不传转换后的 n

// _increment_calculate：重新读原始参数
int n = getParam<int>("n");  // n=0
for (int j = 0; j < n; j++) { ... }  // 循环不执行
if (act_count < 2) return;           // 永远走这里，dst 不写
```

`_calculate` 中的 `n = total` 只是局部变量遮蔽，无法跨函数传给被委托者。`ICorr`/`ICov` 同样支持 `n=0`，但 `_calculate` 自带完整计算循环、不委托 `_increment_calculate`，故不受影响。

## 修复方案

在 `_increment_calculate` 入口补与 `_calculate` 一致的归一化：

```cpp
int n = getParam<int>("n");
if (n == 0) {
    n = total;
}
```

### 关键设计决策

1. **最小补丁**：只在被委托端补二次归一化，不重构委托模式、不改 API。
2. **不改 `supportIncrementCalculate` / `min_increment_start`**：`n=0` 时前者返回 `false`，框架强制全量重算，只走 `_calculate → _increment_calculate` 一条路径。
3. **修复后语义与 CORR(n=0) 一致**：`discard = total - 1`（无输入 discard 时），仅末点有值。

## 验证

### 编译

Windows 11 + MSVC + VS2022 + xmake：

```
xmake -j8 -b unit-test
[100%]: build ok
```

### 功能验证

新增 `test_SPEARMAN_n0_full_window`：

| 用例 | 数据/条件 | 期望 | 验证点 |
|------|-----------|------|--------|
| n=0 等价 n=total | a={3,8,4,7,2} b={5,10,8,10,6} | discard=4, result[4]=0.872082，且等于 `SPEARMAN(..., n=5)` 末点 | 硬编码钉死修复前全 NaN |
| 空序列 n=0 | 空 Indicator | empty | 不越界 |
| 极短 total=1, n=0 | 单点 | discard=0, result[0]=NaN | n→1 后 m_discard=0；act_count&lt;2 不写值 |
| 下界 total=2, n=0 | a={1,2} b={2,1} | discard=1, result[1]=-1.0 | 恰好 act_count==2，完全负相关 |
| 输入带 discard | total=5, ind.discard=2, n=0 | discard=5 | m_discard=6&gt;5 全量失效 |

### 回归测试

SPEARMAN 相关子集：

```
[doctest] test cases:  5 |  5 passed | 0 failed
[doctest] assertions: 79 | 79 passed | 0 failed
```

完整套件：

```
[doctest] test cases:    746 |    746 passed | 0 failed | 0 skipped
[doctest] assertions: 197363 | 197363 passed | 0 failed |
[doctest] Status: SUCCESS!
```

746 用例全绿，0 回归。

## 改动范围

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/imp/ISpearman.cpp` | +5：`_increment_calculate` 入口 n=0→total |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_SPEARMAN.cpp` | 新增 `test_SPEARMAN_n0_full_window`（5 子用例） |

合计 2 文件，+55。不改 API 签名/返回类型。

## 性能影响

无。仅多一次 `if (n == 0)` 分支判断；n=0 路径原先不产出结果，修复后只在末点做一次全窗口排序相关（与显式 `n=total` 同阶）。