### PR TITLE
fix(allocatefunds): adjust_running_sys=false 时 running 占用权重误用总账户资产

### DIFF
--- a/hikyuu_cpp/hikyuu/trade_sys/allocatefunds/AllocateFundsBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/allocatefunds/AllocateFundsBase.cpp
@@ -226,12 +226,13 @@ void AllocateFundsBase::_adjust_without_running(const Datetime& date,
             continue;
         }
 
-        // 如果是运行中系统，不使用计算的权重，更新累积权重和
+        // 如果是运行中系统，不使用计算的权重，按子系统实际资产更新累积占用权重
+        // 注意：必须用 sub_tm，不能用总账户 m_tm（否则每个 running 都会把 sum_weight 抬到 ~1）
+        // kType 使用 AF 统一的 m_query，保证与 total_funds 同一估值上下文
         if (running_set.find(iter->sys) != running_set.cend()) {
-            FundsRecord sub_funds = m_tm->getFunds(date, m_query.kType());
-            price_t sub_total_funds = sub_funds.cash + sub_funds.market_value +
-                                      sub_funds.borrow_asset - sub_funds.short_market_value;
-            sum_weight += sub_total_funds / total_funds;
+            TMPtr sub_tm = iter->sys->getTM();
+            FundsRecord sub_funds = sub_tm->getFunds(date, m_query.kType());
+            sum_weight += sub_funds.total_assets() / total_funds;
             continue;
         }
 

--- a/hikyuu_cpp/unit_test/hikyuu/trade_sys/allocatefunds/test_AF_EqualWeight.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/trade_sys/allocatefunds/test_AF_EqualWeight.cpp
@@ -11,8 +11,24 @@
 #include <hikyuu/trade_sys/system/crt/SYS_Simple.h>
 #include <hikyuu/trade_sys/selector/crt/SE_Fixed.h>
 #include <hikyuu/trade_sys/allocatefunds/crt/AF_EqualWeight.h>
+#include <hikyuu/trade_sys/allocatefunds/AllocateFundsBase.h>
+#include <memory>
+#include <unordered_set>
 
 using namespace hku;
+
+// 透传 se_list 权重，避免 AF_EqualWeight 把权重改成全 1.0 导致排序/断言不可控
+class AF_PassThroughWeight : public AllocateFundsBase {
+public:
+    AF_PassThroughWeight() : AllocateFundsBase("AF_PassThroughWeight") {}
+    AFPtr _clone() override {
+        return std::make_shared<AF_PassThroughWeight>();
+    }
+    SystemWeightList _allocateWeight(const Datetime&, const SystemWeightList& se_list) override {
+        return se_list;
+    }
+};
+
 
 /**
  * @defgroup test_AllocateFunds test_AllocateFunds
@@ -63,6 +79,122 @@ TEST_CASE("test_AF_EqualWeight_not_adjust_hold") {
     std::cout.precision();
     */
 }
+
+/** @par adjust_running_sys=false 时，running 系统占用权重应按子系统资产计算 */
+TEST_CASE("test_AF_without_running_uses_sub_tm_funds") {
+    StockManager& sm = StockManager::instance();
+    Stock stock = sm["sz000001"];
+    CHECK_UNARY(!stock.isNull());
+
+    // 调仓日：晚于买入日，触发 getFunds(date) 持仓市值重估路径
+    Datetime buy_date(201101040000L);
+    Datetime date(201101050000L);
+
+    // 总账户账面 100000；影子资金账户可分配 100000
+    // （简化 PF 账本：m_tm 作总资产参考，m_cash_tm 为可分配池，sub_tm 为子系统）
+    // cash_tm 给足，避免场景2被现金上限掩盖权重截断断言
+    TMPtr tm = crtTM(Datetime(200101010000L), 100000);
+    TMPtr cash_tm = crtTM(Datetime(200101010000L), 100000);
+
+    // running：现金 + 持仓，确保 total_assets 走 cash+market_value，而非纯现金捷径
+    TMPtr sub_tm_running = crtTM(Datetime(200101010000L), 30000);
+    price_t buy_price = 10.0;
+    double buy_num = 1000;
+    auto tr = sub_tm_running->buy(buy_date, stock, buy_price, buy_num, 0.0, buy_price, buy_price);
+    CHECK_UNARY(!tr.isNull());
+
+    FundsRecord running_funds = sub_tm_running->getFunds(date, KQuery::DAY);
+    CHECK_GT(running_funds.market_value, 0.0);
+    price_t running_assets = running_funds.total_assets();
+    CHECK_GT(running_assets, 0.0);
+    CHECK_LT(running_assets, 100000.0);  // 占用权重 < 1，否则本用例无法验证新系统分配
+    CHECK_LT(running_assets, 80000.0);   // 场景1 计划权重 0.2 不被截断的前提：w_run < 0.8
+
+    TMPtr sub_tm_new = crtTM(Datetime(200101010000L), 0);
+    SYSPtr sys_running = SYS_Simple(sub_tm_running);
+    SYSPtr sys_new = SYS_Simple(sub_tm_new);
+
+    // 使用透传权重 AF，确保 se_list 中 0.8/0.2 等指定权重不被 EqualWeight 抹平
+    AFPtr af = std::make_shared<AF_PassThroughWeight>();
+    af->setParam<bool>("adjust_running_sys", false);
+    af->setParam<bool>("auto_adjust_weight", false);  // 指定权重，保证 running 先被遍历
+    af->setParam<double>("reserve_percent", 0.0);
+    af->setTM(tm);
+    af->setCashTM(cash_tm);
+    af->setQuery(KQueryByDate(Datetime(201101010000L), Datetime(201201010000L)));
+
+    // -----------------------------------------------------------------
+    // 场景 1：running 权重更高，排序后先处理；修复前 sum_weight≈1 导致新系统分到 0
+    // -----------------------------------------------------------------
+    {
+        SystemWeightList se_list;
+        se_list.emplace_back(sys_running, 0.8);
+        se_list.emplace_back(sys_new, 0.2);
+
+        std::unordered_set<SYSPtr> running_set;
+        running_set.insert(sys_running);
+
+        price_t cash_before = cash_tm->currentCash();
+        price_t running_cash_before = sub_tm_running->currentCash();
+
+        af->adjustFunds(date, se_list, running_set);
+
+        // 新系统按计划权重 0.2 分配：will_cash = total_funds * 0.2 = 20000
+        // （running 实际占用 running_assets/100000 < 0.8，不会截断 0.2）
+        CHECK_EQ(sys_new->getTM()->currentCash(), doctest::Approx(20000.0));
+        // without_running 不调 running 仓位/现金
+        CHECK_EQ(sub_tm_running->currentCash(), doctest::Approx(running_cash_before));
+        CHECK_EQ(cash_tm->currentCash(), doctest::Approx(cash_before - 20000.0));
+    }
+
+    // -----------------------------------------------------------------
+    // 场景 2：剩余权重截断——running 实际占用后，新系统计划权重被 can_allocate_weight-sum_weight 截断
+    // 重置新系统与 cash_tm 后复用同一 running
+    // -----------------------------------------------------------------
+    {
+        // 回收场景1 分给新系统的资金
+        price_t new_cash = sub_tm_new->currentCash();
+        if (new_cash > 0.0) {
+            CHECK_UNARY(sub_tm_new->checkout(date, new_cash));
+            CHECK_UNARY(cash_tm->checkin(date, new_cash));
+        }
+        CHECK_EQ(sub_tm_new->currentCash(), doctest::Approx(0.0));
+
+        // 计划权重：running 0.9（先遍历），new 0.8；running 实际占用 w_run 后，new 只能拿到 1-w_run
+        SystemWeightList se_list;
+        se_list.emplace_back(sys_running, 0.9);
+        se_list.emplace_back(sys_new, 0.8);
+
+        std::unordered_set<SYSPtr> running_set;
+        running_set.insert(sys_running);
+
+        price_t total_funds = tm->getFunds(date, KQuery::DAY).total_assets();
+        price_t w_run = running_assets / total_funds;
+        // 与 _adjust_without_running 相同的截断公式
+        price_t plan_w = 0.8;
+        price_t current_weight =
+          (plan_w + w_run > 1.0) ? (1.0 - w_run) : plan_w;
+        // 实现里对 will_cash 做 roundUp(..., precision)，默认 precision=2
+        price_t expect_new_cash = total_funds * current_weight;
+        price_t cash_before = cash_tm->currentCash();
+        if (expect_new_cash > cash_before) {
+            expect_new_cash = cash_before;
+        }
+        // 场景意图：必须发生截断，否则测不到 sum_weight 挤占
+        CHECK_GT(plan_w + w_run, 1.0);
+
+        af->adjustFunds(date, se_list, running_set);
+
+        // scale/epsilon 覆盖 roundUp(precision=2) 与浮点权重误差
+        CHECK_EQ(sys_new->getTM()->currentCash(),
+                 doctest::Approx(expect_new_cash).scale(1).epsilon(0.01));
+        CHECK_EQ(cash_tm->currentCash(),
+                 doctest::Approx(cash_before - expect_new_cash).scale(1).epsilon(0.01));
+        // 明确低于计划权重 0.8 对应资金，证明发生了截断而非按 plan 全额分配
+        CHECK_LT(sys_new->getTM()->currentCash(), total_funds * plan_w - 1.0);
+    }
+}
+
 
 //-----------------------------------------------------------------------------
 // test export


### PR DESCRIPTION
## 问题概述

`AllocateFundsBase::_adjust_without_running`（`adjust_running_sys=false`）在累计已运行系统占用权重时，误用总账户 `m_tm` 的资产而非子系统 `sub_tm` 资产。每个 running 系统都会把 `sum_weight` 抬到约 1，循环随后因 `sum_weight >= can_allocate_weight` 截断，导致其后新系统几乎分不到资金。

## 根因分析

`_adjust_without_running` 中 running 分支：

```cpp
// 修复前
FundsRecord sub_funds = m_tm->getFunds(date, m_query.kType());
price_t sub_total_funds = sub_funds.cash + sub_funds.market_value
                        + sub_funds.borrow_asset - sub_funds.short_market_value;
sum_weight += sub_total_funds / total_funds;
```

同函数内 `total_funds` 也来自 `m_tm->getFunds(...)`，因此：

```
sub_total_funds / total_funds ≈ 1
```

变量名 `sub_funds` / `sub_total_funds` 与注释「已运行系统实际占用比例」均表明意图是子系统资产占比。对照 `_adjust_with_running` 正确使用 `iter->sys->getTM()->getFunds(...)`，可确认此处为账户对象误用。

影响范围：

| 场景 | 影响 |
|------|------|
| `adjust_running_sys=true`（默认） | 无，走 `_adjust_with_running` |
| `adjust_running_sys=false` 且 `running_set` 为空 | 无 |
| `adjust_running_sys=false` 且存在 running | 扫到第一个 running 后截断后续分配 |

## 修复方案

将 running 占用权重改为子系统账户资产，并与总资产使用同一 `m_query.kType()` 估值上下文：

```cpp
TMPtr sub_tm = iter->sys->getTM();
FundsRecord sub_funds = sub_tm->getFunds(date, m_query.kType());
sum_weight += sub_funds.total_assets() / total_funds;
```

设计决策：

1. **账户对象**：`sub_tm`（与 `_adjust_with_running` 一致），分母 `total_funds` 仍取自 `m_tm`。
2. **kType**：使用 AF 的 `m_query.kType()`，与同函数 `total_funds` 估值上下文一致；不依赖子系统 `getTO()`（新系统可能尚未绑定 TO）。
3. **`total_assets()`**：等价于 `cash + market_value + borrow_asset - short_market_value`，避免重复展开公式。
4. **范围**：仅修 `_adjust_without_running` 这一处误用；不改默认参数、不重构 `_adjust_with_running`。

## 验证

### 编译

`local/dev` + MSVC/VS2022，`xmake -j14 -b unit-test`，build ok。

### 功能验证

新增 `test_AF_without_running_uses_sub_tm_funds`（透传权重 AF，避免 `AF_EqualWeight` 把权重抹成全 1）：

| 数据 | 修复前 | 修复后 | 验证点 |
|------|--------|--------|--------|
| 总资产 100000；running 含现金+持仓；new 初始 0；running 权重 0.8 先遍历，new 权重 0.2 | new 现金 ≈ 0 | new 现金 = 20000 | 根因反例：不再因 running 把 sum_weight 抬到 1 而饿死新系统 |
| 同上；running 现金不变 | — | running 现金未变 | without_running 不调 running 仓位 |
| plan new=0.8，但 running 实际占用 w_run 使 w_run+0.8>1 | 可能 new=0 或行为错误 | new = total×(1−w_run)（并严格 < total×0.8） | 实际占用挤占后的权重截断 |

前置条件：running 通过 `buy` 持有 sz000001，调仓日晚于买入日，确保 `getFunds(date)` 走 `market_value > 0` 路径，而非纯现金捷径。

单测：`test_AF_without_running_uses_sub_tm_funds` 16 assertions 全绿。

### 回归测试

完整 unit-test 套件：

- test cases: **746 passed / 0 failed**
- assertions: **197364 passed / 0 failed**

## 改动范围

| 文件 | 变更 |
|------|------|
| `hikyuu_cpp/hikyuu/trade_sys/allocatefunds/AllocateFundsBase.cpp` | running 占用权重改用 `sub_tm` |
| `hikyuu_cpp/unit_test/hikyuu/trade_sys/allocatefunds/test_AF_EqualWeight.cpp` | 新增反例 + 截断场景单测 |

约 +138 / −5。

## 性能影响

无。仍为每个 running 一次 `getFunds`，仅修正调用对象。