### PR TITLE
fix(signal): SignalBase::clone 错误复制 m_cycle_end 导致周期边界损坏

### DIFF
--- a/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp
@@ -69,7 +69,7 @@ SignalPtr SignalBase::clone() {
     p->m_buySig = m_buySig;
     p->m_sellSig = m_sellSig;
     p->m_cycle_start = m_cycle_start;
-    p->m_cycle_end = m_cycle_start;
+    p->m_cycle_end = m_cycle_end;
     return p;
 }
 

--- a/hikyuu_cpp/unit_test/hikyuu/trade_sys/signal/test_Signal.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/trade_sys/signal/test_Signal.cpp
@@ -8,6 +8,8 @@
 #include "doctest/doctest.h"
 #include <hikyuu/StockManager.h>
 #include <hikyuu/trade_sys/signal/SignalBase.h>
+#include <hikyuu/trade_sys/signal/crt/SG_Cycle.h>
+#include <hikyuu/KData.h>
 
 using namespace hku;
 
@@ -160,6 +162,69 @@ TEST_CASE("test_Signal") {
         CHECK_EQ(p->shouldSell(Datetime(200101010000)), false);
         CHECK_EQ(p->shouldSell(Datetime(200101040000)), true);
     }
+}
+
+
+/** @par 检测点 */
+TEST_CASE("test_Signal_clone_cycle_bounds") {
+    StockManager &sm = StockManager::instance();
+    Stock stock = sm.getStock("sh000001");
+    KData k = stock.getKData(KQuery(-30));
+    REQUIRE(k.size() >= 15);
+
+    SignalPtr p(new SignalTest);
+    p->setParam<bool>("cycle", true);
+    p->setTO(k);
+
+    Datetime t0 = k[0].datetime;
+    Datetime t1 = k[10].datetime;
+    REQUIRE(t0 < t1);
+    p->startCycle(t0, t1);
+
+    CHECK_EQ(p->getCycleStart(), t0);
+    CHECK_EQ(p->getCycleEnd(), t1);
+
+    /** @arg clone 后周期边界必须完整复制，不能把 end 写成 start */
+    SignalPtr c = p->clone();
+    CHECK_NE(p, c);
+    CHECK_EQ(c->getCycleStart(), t0);
+    CHECK_EQ(c->getCycleEnd(), t1);
+}
+
+/** @par 检测点 */
+TEST_CASE("test_Signal_clone_operator_behavior") {
+    StockManager &sm = StockManager::instance();
+    Stock stock = sm.getStock("sh000001");
+    KData k = stock.getKData(KQuery(-30));
+    REQUIRE(k.size() >= 15);
+
+    Datetime t0 = k[0].datetime;
+    Datetime t1 = k[10].datetime;
+    REQUIRE(t0 < t1);
+
+    // 父信号：cycle=true，已 startCycle（模拟 Operator 父节点持有周期边界）
+    SignalPtr parent(new SignalTest);
+    parent->setParam<bool>("cycle", true);
+    parent->setTO(k);
+    parent->startCycle(t0, t1);
+    CHECK_EQ(parent->getCycleStart(), t0);
+    CHECK_EQ(parent->getCycleEnd(), t1);
+
+    // clone 后边界必须完整；修前 end 会变成 t0
+    SignalPtr cloned = parent->clone();
+    CHECK_EQ(cloned->getCycleStart(), t0);
+    CHECK_EQ(cloned->getCycleEnd(), t1);
+
+    // 模拟 OperatorSignal::sub_sg_calculate 的级联：
+    //   child->startCycle(parent.m_cycle_start, parent.m_cycle_end)
+    // 修前：startCycle(t0, t0) 触发 HKU_CHECK(start < close)
+    // 修后：startCycle(t0, t1) 合法通过并产生买入信号
+    auto child = SG_Cycle();
+    child->setTO(k);
+    REQUIRE_NOTHROW(child->startCycle(cloned->getCycleStart(), cloned->getCycleEnd()));
+    CHECK_EQ(child->getCycleStart(), t0);
+    CHECK_EQ(child->getCycleEnd(), t1);
+    CHECK_EQ(child->getBuyValue(t0), 1.0);
 }
 
 /** @} */


### PR DESCRIPTION
## 问题概述

`SignalBase::clone()` 将 `m_cycle_end` 误赋为 `m_cycle_start`，使 `cycle=true` 的信号在 **已 `startCycle` 之后再 clone** 时周期窗口坍缩为零长度。随后若经 `OperatorSignal::sub_sg_calculate` 把父边界下传给子信号，会触发 `startCycle(start, end)` 的 `start < close` 校验失败并抛异常，组合调仓路径可直接崩溃。

## 根因分析

`clone()` 在复制周期边界时把两行都写成了 `m_cycle_start`（2024-04-02 同 commit 引入，典型 copy-paste）：

```cpp
// SignalBase.cpp::clone（修复前）
p->m_cycle_start = m_cycle_start;
p->m_cycle_end = m_cycle_start;  // 笔误：应为 m_cycle_end
```

合法周期由 `startCycle` 写入，且强校验 `start < close`：

```cpp
void SignalBase::startCycle(const Datetime& start, const Datetime& close) {
    HKU_IF_RETURN(!getParam<bool>("cycle"), void());
    HKU_CHECK(start != Null<Datetime>() && close != Null<Datetime>() && start < close, ...);
    HKU_CHECK(start >= m_cycle_end || m_cycle_end == Null<Datetime>(), ...);
    m_cycle_start = start;
    m_cycle_end = close;
    KData kdata = m_kdata.getKData(start, close);
    if (!kdata.empty()) {
        _calculate(kdata);
    }
}
```

`OperatorSignal` 用父对象边界驱动子信号：

```cpp
void OperatorSignal::sub_sg_calculate(SignalPtr& sg, const KData& kdata) {
    if (sg->getParam<bool>("cycle")) {
        sg->startCycle(m_cycle_start, m_cycle_end);  // 依赖父 clone 后的边界正确
    }
    sg->_calculate(kdata);
}
```

| 场景 | 是否触发 |
|------|----------|
| `cycle=false`（默认） | 否，边界常为 `Null` |
| 先 clone 再 `startCycle`（多数原型复制） | 潜伏；两端多为 `Null`，首次 `startCycle` 写对 |
| **已 `startCycle` 后再 clone** | **触发**；`getCycleEnd()` 退化为 start |
| clone 后经 Operator 级联 `sub_sg_calculate` | **触发**；`startCycle(start, start)` 撞 `start < close` 抛异常 |
| clone 后立刻再 `startCycle(新周期)` | 常被掩盖：校验退化为 `start_new >= start_old`，随后重写 end |

该错误在「先 clone 再 startCycle」或调仓重设路径上不易暴露，但已 `startCycle` 后再 clone 时边界会损坏；组合信号经 `sub_sg_calculate` 下传时可能直接触发 `start < close` 校验异常。

## 修复方案

单行纠正赋值，使 clone 成为状态镜像：

```diff
     p->m_cycle_start = m_cycle_start;
-    p->m_cycle_end = m_cycle_start;
+    p->m_cycle_end = m_cycle_end;
```

### 关键设计决策

1. **只改错误赋值，不在 clone 中加边界合法性断言**：`clone` 职责是镜像当前状态；`start < close` 等不变式由 `startCycle` 负责。
2. **不重置 `m_calculated`**：已计算状态与 KData/信号表一并克隆；需要重算时由 `setTO` / `startCycle` 触发。
3. **不序列化 `m_cycle_*`**：与既有设计一致——周期边界属运行时上下文，序列化只保留参数与结构。

## 验证

### 编译

- 环境：Windows + MSVC 2022 + xmake，在 `local/dev`（含编译适配）上合并本改动后构建
- 结果：`xmake -b unit-test` 通过（仅既有 `utils.cpp` C4018 warning，与本改动无关）

### 功能验证

| 用例 | 数据 / 步骤 | 修复前 | 修复后 | 验证点 |
|------|-------------|--------|--------|--------|
| `test_Signal_clone_cycle_bounds` | `cycle=true`，`startCycle(T0,T1)` → clone | `getCycleEnd()==T0` | `getCycleEnd()==T1` | 状态断言：end 必须完整复制 |
| `test_Signal_clone_operator_behavior` | 父已 `startCycle(T0,T1)` → clone → 子 `SG_Cycle` 调用 `startCycle(cloned.start, cloned.end)`（等价 `OperatorSignal::sub_sg_calculate` 级联） | `startCycle(T0,T0)` 抛异常 | 不抛；子边界 `[T0,T1]`，买入值 1.0 | 行为断言：用 clone 后边界驱动子信号，修前必红、修后必绿 |

行为测试用公开 API 复现级联（`child->startCycle(clone.getCycleStart(), clone.getCycleEnd())`），避免「clone 后再对父 `startCycle` 自愈」假绿；也不依赖 `m_buySig` 拷贝掩盖边界错误。

### 回归测试

- 新增相关：2 用例 17 断言通过
- **完整测试套件：757 用例全部通过，0 失败，0 回归**（198211 断言全绿）

### 同模式扫库

对 `trade_sys/**` 中 `p->m_xxx = m_yyy` 且左右成员名不一致的 clone 赋值扫描：**仅本处一处**，修复后为 0。

## 改动范围

| 文件 | 变更 |
|------|------|
| `hikyuu_cpp/hikyuu/trade_sys/signal/SignalBase.cpp` | +1 / -1 |
| `hikyuu_cpp/unit_test/hikyuu/trade_sys/signal/test_Signal.cpp` | +65 |

合计约 +66 / -1，2 文件。

## 性能影响

无。赋值纠正，时间/空间复杂度不变。