### PR TITLE
perf(factor): reuse compiled factor execution plans

### DIFF
--- a/hikyuu_cpp/hikyuu/factor/FactorSet.cpp
+++ b/hikyuu_cpp/hikyuu/factor/FactorSet.cpp
@@ -242,14 +242,6 @@ vector<IndicatorList> FactorSet::getValues(const StockList& stocks, const KQuery
 
             auto* task_group = get_global_task_group();
             HKU_ASSERT(task_group);
-            if (GlobalStealThreadPool::is_work_thread()) {
-                auto executor = plan.createExecutor();
-                for (size_t i = 0; i < stk_total; ++i) {
-                    result[i] = calculate_one(executor, i);
-                }
-                return result;
-            }
-
             auto ranges = parallelIndexRange(0, stk_total, task_group->worker_num());
             vector<std::future<void>> tasks;
             tasks.reserve(ranges.size());

--- a/hikyuu_cpp/hikyuu/factor/FactorSet.cpp
+++ b/hikyuu_cpp/hikyuu/factor/FactorSet.cpp
@@ -5,10 +5,15 @@
  *      Author: fasiondog
  */
 
+#include <algorithm>
+
 #include "hikyuu/StockManager.h"
+#include "hikyuu/indicator/crt/ALIGN.h"
+#include "hikyuu/indicator/crt/PRICELIST.h"
 #include "hikyuu/plugin/factor.h"
 #include "hikyuu/plugin/device.h"
 #include "FactorSet.h"
+#include "imp/CompiledFactorPlan.h"
 
 namespace hku {
 
@@ -195,6 +200,73 @@ vector<IndicatorList> FactorSet::getValues(const StockList& stocks, const KQuery
     if (driver_type == "clickhouse") {
         result = hku::getValues(*this, stocks, query, align, fill_null, tovalue, align_dates);
         return result;
+    }
+
+    // Formula-bearing results must keep independent graphs. The compiled plan is therefore an
+    // internal value-only fast path and is not observable through the existing public API.
+    if (tovalue) {
+        const size_t stk_total = stocks.size();
+        const size_t factor_total = m_data->factors.size();
+        result.resize(stk_total, IndicatorList(factor_total));
+        HKU_IF_RETURN(stk_total == 0 || factor_total == 0, result);
+
+        DatetimeList dates;
+        Indicator null_ind;
+        if (align) {
+            dates = align_dates.empty() ? StockManager::instance().getTradingCalendar(query)
+                                        : align_dates;
+            HKU_IF_RETURN(dates.empty(), result);
+            null_ind = PRICELIST(PriceList(dates.size(), Null<price_t>()), dates);
+        }
+
+        IndicatorList formulas;
+        formulas.reserve(factor_total);
+        for (const auto& factor : m_data->factors) {
+            formulas.emplace_back(align ? ALIGN(factor.formula(), dates, fill_null)
+                                        : factor.formula());
+        }
+        const detail::CompiledFactorPlan plan(formulas);
+        if (plan.isReusable()) {
+            auto calculate_one = [&](detail::FactorPlanExecutor& executor, size_t i) {
+                IndicatorList one_result(factor_total);
+                KData kdata = stocks[i].getKData(query);
+                if (kdata.empty()) {
+                    if (align) {
+                        std::fill(one_result.begin(), one_result.end(), null_ind);
+                    }
+                    return one_result;
+                }
+
+                return executor.executeValues(kdata);
+            };
+
+            auto* task_group = get_global_task_group();
+            HKU_ASSERT(task_group);
+            if (GlobalStealThreadPool::is_work_thread()) {
+                auto executor = plan.createExecutor();
+                for (size_t i = 0; i < stk_total; ++i) {
+                    result[i] = calculate_one(executor, i);
+                }
+                return result;
+            }
+
+            auto ranges = parallelIndexRange(0, stk_total, task_group->worker_num());
+            vector<std::future<void>> tasks;
+            tasks.reserve(ranges.size());
+            for (const auto& range : ranges) {
+                tasks.emplace_back(task_group->submit([&, range]() {
+                    auto executor = plan.createExecutor();
+                    for (size_t i = range.first; i < range.second; ++i) {
+                        result[i] = calculate_one(executor, i);
+                    }
+                }));
+            }
+            wait_for_all_non_blocking(*task_group, tasks);
+            for (auto& task : tasks) {
+                task.get();
+            }
+            return result;
+        }
     }
 
     // 创建结果容器，每个股票对应一个 IndicatorList

--- a/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
+++ b/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
@@ -252,9 +252,11 @@ CompiledFactorPlan::CompiledFactorPlan(const IndicatorList& formulas) {
     }
 
     m_roots.reserve(formulas.size());
+    CloneMap clones;
     for (const auto& formula : formulas) {
-        m_roots.emplace_back(formula.clone());
+        m_roots.emplace_back(cloneNode(formula.getImp(), clones));
     }
+    normalizeParents(m_roots);
 
     std::unordered_set<IndicatorImp*> scrubbed;
     for (const auto& root : m_roots) {

--- a/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
+++ b/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
@@ -1,0 +1,325 @@
+/*
+ *  Copyright (c) 2026 hikyuu.org
+ *
+ *  Internal compiled execution plan for stock-local factor formulas.
+ */
+
+#include <algorithm>
+
+#include "hikyuu/indicator/IndicatorImp.h"
+#include "CompiledFactorPlan.h"
+
+namespace hku {
+namespace detail {
+
+IndicatorImpPtr CompiledFactorPlan::cloneNode(const IndicatorImpPtr& src, CloneMap& clones) {
+    if (!src) {
+        return {};
+    }
+
+    auto iter = clones.find(src.get());
+    if (iter != clones.end()) {
+        return iter->second;
+    }
+
+    // Indicator2InImp::_clone() currently clones its private reference graph independently. The
+    // executor still rebinds that graph correctly, but sharing inside it is not preserved yet.
+    IndicatorImpPtr dst = src->_clone();
+    clones.emplace(src.get(), dst);
+
+    dst->m_params = src->m_params;
+    dst->m_name = src->m_name;
+    dst->m_is_python_object = src->m_is_python_object;
+    dst->m_need_self_alike_compare = src->m_need_self_alike_compare;
+    dst->m_is_serial = src->m_is_serial;
+    dst->m_discard = src->m_discard;
+    dst->m_result_num = src->m_result_num;
+    dst->m_context = src->m_context;
+    dst->m_old_context = src->m_old_context;
+    dst->m_need_calculate = src->m_need_calculate;
+    dst->m_param_changed = src->m_param_changed;
+    dst->m_optype = src->m_optype;
+    dst->m_parent = nullptr;
+
+    dst->_readyBuffer(src->size(), src->m_result_num);
+    for (size_t i = 0; i < src->m_result_num; ++i) {
+        if (src->m_pBuffer[i]) {
+            std::copy(src->m_pBuffer[i]->begin(), src->m_pBuffer[i]->end(),
+                      dst->m_pBuffer[i]->begin());
+        }
+    }
+
+    dst->m_left = cloneNode(src->m_left, clones);
+    dst->m_right = cloneNode(src->m_right, clones);
+    dst->m_three = cloneNode(src->m_three, clones);
+    if (dst->m_left) {
+        dst->m_left->m_parent = dst.get();
+    }
+    if (dst->m_right) {
+        dst->m_right->m_parent = dst.get();
+    }
+    if (dst->m_three) {
+        dst->m_three->m_parent = dst.get();
+    }
+
+    dst->m_ind_params.clear();
+    for (const auto& [name, value] : src->m_ind_params) {
+        dst->m_ind_params[name] = cloneNode(value, clones);
+    }
+
+    return dst;
+}
+
+IndicatorImpPtr CompiledFactorPlan::canonicalizeNode(const IndicatorImpPtr& node,
+                                                     CanonicalMap& canonical,
+                                                     vector<IndicatorImpPtr>& unique_nodes) {
+    if (!node) {
+        return {};
+    }
+
+    auto iter = canonical.find(node.get());
+    if (iter != canonical.end()) {
+        return iter->second;
+    }
+
+    node->m_left = canonicalizeNode(node->m_left, canonical, unique_nodes);
+    node->m_right = canonicalizeNode(node->m_right, canonical, unique_nodes);
+    node->m_three = canonicalizeNode(node->m_three, canonical, unique_nodes);
+    for (auto& [_, value] : node->m_ind_params) {
+        value = canonicalizeNode(value, canonical, unique_nodes);
+    }
+
+    for (const auto& candidate : unique_nodes) {
+        if (candidate->alike(*node)) {
+            canonical.emplace(node.get(), candidate);
+            return candidate;
+        }
+    }
+
+    unique_nodes.emplace_back(node);
+    canonical.emplace(node.get(), node);
+    return node;
+}
+
+void CompiledFactorPlan::prepareNode(const IndicatorImpPtr& node, const KData& kdata,
+                                     std::unordered_set<IndicatorImp*>& visited) {
+    if (!node || !visited.emplace(node.get()).second) {
+        return;
+    }
+
+    node->onlySetContext(kdata);
+    node->m_old_context = KData();
+    node->m_need_calculate = true;
+    node->m_param_changed = true;
+    node->m_discard = 0;
+
+    // CONTEXT owns a deliberately independent input context. Its implementation is responsible
+    // for rebinding that private subgraph when the outer context changes.
+    if (node->name() == "CONTEXT") {
+        return;
+    }
+
+    prepareNode(node->m_left, kdata, visited);
+    prepareNode(node->m_right, kdata, visited);
+    prepareNode(node->m_three, kdata, visited);
+    for (const auto& [_, value] : node->m_ind_params) {
+        prepareNode(value, kdata, visited);
+        value->calculate();
+    }
+
+    vector<IndicatorImpPtr> inner_nodes;
+    node->getSelfInnerNodesWithInputConext(inner_nodes);
+    for (const auto& inner : inner_nodes) {
+        prepareNode(inner, kdata, visited);
+    }
+}
+
+bool CompiledFactorPlan::isEligibleNode(const IndicatorImpPtr& node,
+                                        std::unordered_set<const IndicatorImp*>& visited) {
+    if (!node || !visited.emplace(node.get()).second) {
+        return true;
+    }
+
+    // Python implementations can retain arbitrary state that the C++ executor cannot reset.
+    // CONTEXT contains a private independently-bound graph and stays on the proven legacy path.
+    if (!node->supportBatchReuse() || node->name() == "CONTEXT") {
+        return false;
+    }
+
+    if (!isEligibleNode(node->m_left, visited) || !isEligibleNode(node->m_right, visited) ||
+        !isEligibleNode(node->m_three, visited)) {
+        return false;
+    }
+    for (const auto& [_, value] : node->m_ind_params) {
+        if (!isEligibleNode(value, visited)) {
+            return false;
+        }
+    }
+
+    vector<IndicatorImpPtr> inner_nodes;
+    node->getSelfInnerNodesWithInputConext(inner_nodes);
+    for (const auto& inner : inner_nodes) {
+        if (!isEligibleNode(inner, visited)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void CompiledFactorPlan::scrubTemplateNode(const IndicatorImpPtr& node,
+                                           std::unordered_set<IndicatorImp*>& visited) {
+    if (!node || !visited.emplace(node.get()).second) {
+        return;
+    }
+
+    node->m_context = KData();
+    node->m_old_context = KData();
+    node->m_need_calculate = true;
+    node->m_param_changed = true;
+    if (!node->isLeaf() || node->isNeedContext()) {
+        node->_clearBuffer();
+        node->m_discard = 0;
+    }
+
+    scrubTemplateNode(node->m_left, visited);
+    scrubTemplateNode(node->m_right, visited);
+    scrubTemplateNode(node->m_three, visited);
+    for (const auto& [_, value] : node->m_ind_params) {
+        scrubTemplateNode(value, visited);
+    }
+
+    vector<IndicatorImpPtr> inner_nodes;
+    node->getSelfInnerNodesWithInputConext(inner_nodes);
+    for (const auto& inner : inner_nodes) {
+        scrubTemplateNode(inner, visited);
+    }
+}
+
+void CompiledFactorPlan::normalizeParents(const IndicatorList& roots) {
+    using ParentInfo = std::pair<size_t, IndicatorImp*>;
+    std::unordered_map<IndicatorImp*, ParentInfo> parents;
+    std::unordered_set<IndicatorImp*> visited;
+    vector<IndicatorImpPtr> stack;
+
+    for (const auto& root : roots) {
+        if (root.getImp()) {
+            auto [iter, inserted] = parents.emplace(root.getImp().get(), ParentInfo{1, nullptr});
+            if (!inserted) {
+                ++iter->second.first;
+            }
+            root.getImp()->m_parent = nullptr;
+            stack.emplace_back(root.getImp());
+        }
+    }
+
+    while (!stack.empty()) {
+        IndicatorImpPtr node = std::move(stack.back());
+        stack.pop_back();
+        if (!node || !visited.emplace(node.get()).second) {
+            continue;
+        }
+
+        auto record_child = [&](const IndicatorImpPtr& child) {
+            if (!child) {
+                return;
+            }
+            auto [iter, inserted] = parents.emplace(child.get(), ParentInfo{1, node.get()});
+            if (!inserted) {
+                ++iter->second.first;
+            }
+            stack.emplace_back(child);
+        };
+        record_child(node->m_left);
+        record_child(node->m_right);
+        record_child(node->m_three);
+        for (const auto& [_, value] : node->m_ind_params) {
+            record_child(value);
+        }
+    }
+
+    for (const auto& [node, info] : parents) {
+        node->m_parent = info.first == 1 ? info.second : nullptr;
+    }
+}
+
+CompiledFactorPlan::CompiledFactorPlan(const IndicatorList& formulas) {
+    std::unordered_set<const IndicatorImp*> visited;
+    for (const auto& formula : formulas) {
+        if (!isEligibleNode(formula.getImp(), visited)) {
+            m_reusable = false;
+            return;
+        }
+    }
+
+    m_roots.reserve(formulas.size());
+    for (const auto& formula : formulas) {
+        m_roots.emplace_back(formula.clone());
+    }
+
+    std::unordered_set<IndicatorImp*> scrubbed;
+    for (const auto& root : m_roots) {
+        scrubTemplateNode(root.getImp(), scrubbed);
+    }
+
+    CanonicalMap canonical;
+    vector<IndicatorImpPtr> unique_nodes;
+    for (auto& root : m_roots) {
+        root = Indicator(canonicalizeNode(root.getImp(), canonical, unique_nodes));
+    }
+    normalizeParents(m_roots);
+
+    // Private derived-class graphs are intentionally left to the existing indicator hook. They
+    // remain correct but cannot participate in plan-wide CSE until their ownership is exposed.
+    for (const auto& root : m_roots) {
+        if (root.getImp()) {
+            root.getImp()->repeatSeparateKTypeLeafALikeNodes();
+        }
+    }
+    normalizeParents(m_roots);
+}
+
+IndicatorList CompiledFactorPlan::cloneRoots() const {
+    IndicatorList roots;
+    roots.reserve(m_roots.size());
+
+    CloneMap clones;
+    for (const auto& root : m_roots) {
+        roots.emplace_back(cloneNode(root.getImp(), clones));
+    }
+
+    normalizeParents(roots);
+
+    return roots;
+}
+
+FactorPlanExecutor CompiledFactorPlan::createExecutor() const {
+    return FactorPlanExecutor(cloneRoots());
+}
+
+IndicatorList FactorPlanExecutor::executeValues(const KData& kdata) {
+    if (kdata.empty()) {
+        return IndicatorList(m_roots.size());
+    }
+
+    std::unordered_set<IndicatorImp*> visited;
+    for (const auto& root : m_roots) {
+        CompiledFactorPlan::prepareNode(root.getImp(), kdata, visited);
+    }
+
+    std::unordered_set<IndicatorImp*> executed_roots;
+    for (auto& root : m_roots) {
+        if (root.getImp() && executed_roots.emplace(root.getImp().get()).second) {
+            root.getImp()->calculate();
+        }
+    }
+
+    IndicatorList result;
+    result.reserve(m_roots.size());
+    for (const auto& root : m_roots) {
+        result.emplace_back(root.getResult(0));
+    }
+    return result;
+}
+
+}  // namespace detail
+}  // namespace hku

--- a/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.h
+++ b/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.h
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2026 hikyuu.org
+ *
+ *  Internal compiled execution plan for stock-local factor formulas.
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "hikyuu/indicator/Indicator.h"
+
+namespace hku {
+namespace detail {
+
+class FactorPlanExecutor;
+
+class HKU_API CompiledFactorPlan {
+public:
+    explicit CompiledFactorPlan(const IndicatorList& formulas);
+
+    bool isReusable() const noexcept {
+        return m_reusable;
+    }
+
+    FactorPlanExecutor createExecutor() const;
+
+    size_t size() const noexcept {
+        return m_roots.size();
+    }
+
+private:
+    friend class FactorPlanExecutor;
+    using CloneMap = std::unordered_map<const IndicatorImp*, IndicatorImpPtr>;
+    using CanonicalMap = std::unordered_map<const IndicatorImp*, IndicatorImpPtr>;
+
+    static IndicatorImpPtr cloneNode(const IndicatorImpPtr& src, CloneMap& clones);
+    static IndicatorImpPtr canonicalizeNode(const IndicatorImpPtr& node, CanonicalMap& canonical,
+                                            vector<IndicatorImpPtr>& unique_nodes);
+    static bool isEligibleNode(const IndicatorImpPtr& node,
+                               std::unordered_set<const IndicatorImp*>& visited);
+    static void scrubTemplateNode(const IndicatorImpPtr& node,
+                                  std::unordered_set<IndicatorImp*>& visited);
+    static void prepareNode(const IndicatorImpPtr& node, const KData& kdata,
+                            std::unordered_set<IndicatorImp*>& visited);
+    static void normalizeParents(const IndicatorList& roots);
+    IndicatorList cloneRoots() const;
+
+private:
+    IndicatorList m_roots;
+    bool m_reusable{true};
+};
+
+class HKU_API FactorPlanExecutor {
+public:
+    FactorPlanExecutor(const FactorPlanExecutor&) = delete;
+    FactorPlanExecutor& operator=(const FactorPlanExecutor&) = delete;
+    FactorPlanExecutor(FactorPlanExecutor&&) noexcept = default;
+    FactorPlanExecutor& operator=(FactorPlanExecutor&&) noexcept = default;
+
+    IndicatorList executeValues(const KData& kdata);
+
+private:
+    friend class CompiledFactorPlan;
+    explicit FactorPlanExecutor(IndicatorList roots) : m_roots(std::move(roots)) {}
+
+private:
+    IndicatorList m_roots;
+};
+
+}  // namespace detail
+}  // namespace hku

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -1978,11 +1978,12 @@ bool IndicatorImp::alike(const IndicatorImp &other) const {
                   false);
 
     if (needSelfAlikeCompare()) {
-        return selfAlike(other);
+        HKU_IF_RETURN(!selfAlike(other), false);
+        HKU_IF_RETURN(isLeaf(), true);
     }
 
     auto iter1 = m_ind_params.cbegin();
-    auto iter2 = other.m_ind_params.cend();
+    auto iter2 = other.m_ind_params.cbegin();
     for (; iter1 != m_ind_params.cend() && iter2 != other.m_ind_params.cend(); ++iter1, ++iter2) {
         HKU_IF_RETURN(iter1->first != iter2->first, false);
         HKU_IF_RETURN(!iter1->second->alike(*(iter2->second)), false);
@@ -2001,9 +2002,12 @@ bool IndicatorImp::alike(const IndicatorImp &other) const {
         return eq;
     }
 
-    HKU_IF_RETURN(m_three && other.m_three && !m_three->alike(*other.m_three), false);
-    HKU_IF_RETURN(m_left && other.m_left && !m_left->alike(*other.m_left), false);
-    HKU_IF_RETURN(m_right && other.m_right && !m_right->alike(*other.m_right), false);
+    HKU_IF_RETURN(bool(m_three) != bool(other.m_three) || bool(m_left) != bool(other.m_left) ||
+                    bool(m_right) != bool(other.m_right),
+                  false);
+    HKU_IF_RETURN(m_three && !m_three->alike(*other.m_three), false);
+    HKU_IF_RETURN(m_left && !m_left->alike(*other.m_left), false);
+    HKU_IF_RETURN(m_right && !m_right->alike(*other.m_right), false);
 
     return true;
 }

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -2071,45 +2071,42 @@ void IndicatorImp::inner_repeatALikeNodes(vector<IndicatorImpPtr> &sub_nodes) {
     size_t total = sub_nodes.size();
     for (size_t i = 0; i < total; i++) {
         const auto &cur = sub_nodes[i];
-        if (!cur) {
+        // Detached private roots (such as Indicator2InImp::m_ref_ind) have no generic parent
+        // edge and cannot participate in m_left/m_right/m_three replacement.
+        if (!cur || !cur->m_parent) {
             continue;
         }
         for (size_t j = i + 1; j < total; j++) {
             auto &node = sub_nodes[j];
-            if (!node || cur == node) {
+            if (!node || !node->m_parent || cur == node) {
                 continue;
             }
 
             if (cur->alike(*node)) {
                 IndicatorImp *node_parent = node->m_parent;
-                if (node_parent) {
-                    if (node_parent->m_left == node) {
-                        node_parent->m_left = cur;
-                    }
+                if (node_parent->m_left == node) {
+                    node_parent->m_left = cur;
+                }
 
-                    if (node_parent->m_right == node) {
-                        node_parent->m_right = cur;
-                    }
+                if (node_parent->m_right == node) {
+                    node_parent->m_right = cur;
+                }
 
-                    if (node_parent->m_three == node) {
-                        node_parent->m_three = cur;
-                    }
+                if (node_parent->m_three == node) {
+                    node_parent->m_three = cur;
+                }
 
-                    tmp_nodes.clear();
-                    node->getAllSubNodes(tmp_nodes);
-                    for (const auto &replace_node : tmp_nodes) {
-                        for (size_t k = j + 1; k < total; k++) {
-                            if (replace_node == sub_nodes[k]) {
-                                sub_nodes[k].reset();
-                            }
+                tmp_nodes.clear();
+                node->getAllSubNodes(tmp_nodes);
+                for (const auto &replace_node : tmp_nodes) {
+                    for (size_t k = j + 1; k < total; k++) {
+                        if (replace_node == sub_nodes[k]) {
+                            sub_nodes[k].reset();
                         }
                     }
-
-                    node = cur;
-
-                } else {
-                    HKU_WARN("Exist some errors! node: {} cur: {}", node->name(), cur->name());
                 }
+
+                node = cur;
             }
         }
     }

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
@@ -22,6 +22,10 @@ namespace hku {
 class HKU_API Indicator;
 class HKU_API IndParam;
 
+namespace detail {
+class CompiledFactorPlan;
+}
+
 vector<Indicator> HKU_API combineCalculateIndicators(const vector<Indicator>& indicators,
                                                      const KData& kdata, bool tovalue);
 
@@ -32,6 +36,7 @@ vector<Indicator> HKU_API combineCalculateIndicators(const vector<Indicator>& in
 class HKU_API IndicatorImp : public enable_shared_from_this<IndicatorImp> {
     PARAMETER_SUPPORT_WITH_CHECK
     friend HKU_API std::ostream& operator<<(std::ostream& os, const IndicatorImp& imp);
+    friend class detail::CompiledFactorPlan;
 
     typedef vector<Indicator> IndicatorList;
     friend IndicatorList HKU_API combineCalculateIndicators(const IndicatorList& indicators,
@@ -145,6 +150,15 @@ public:
     IndicatorImpPtr clone();
 
     bool isPythonObject() const noexcept;
+
+    /**
+     * Whether this implementation can be fully recalculated on a reusable batch executor.
+
+     * * Custom C++ indicators that retain state outside IndicatorImp buffers should opt out.
+ */
+    bool supportBatchReuse() const;
+
+    void supportBatchReuse(bool enable);
 
     /** 仅用于两个结果集数量相同、长度相同的指标交换数据，不交换其他参数。失败抛出异常 */
     void swap(IndicatorImp* other);
@@ -539,6 +553,15 @@ inline size_t IndicatorImp::_get_step_start(size_t pos, size_t step, size_t disc
 
 inline bool IndicatorImp::isPythonObject() const noexcept {
     return m_is_python_object;
+}
+
+inline bool IndicatorImp::supportBatchReuse() const {
+    static const string param_name("_support_batch_reuse");
+    return !m_is_python_object && (!haveParam(param_name) || getParam<bool>(param_name));
+}
+
+inline void IndicatorImp::supportBatchReuse(bool enable) {
+    m_params.set<bool>("_support_batch_reuse", enable);
 }
 
 inline IndicatorImpPtr IndicatorImp::getRightNode() const noexcept {

--- a/hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp
@@ -6,17 +6,67 @@
  */
 
 #include "doctest/doctest.h"
+#include <atomic>
 #include <hikyuu/factor/FactorSet.h>
 #include <hikyuu/factor/Factor.h>
+#include <hikyuu/factor/imp/CompiledFactorPlan.h>
+#include <hikyuu/indicator/IndicatorImp.h>
+#include <hikyuu/indicator/crt/ALIGN.h>
+#include <hikyuu/indicator/crt/CONTEXT.h>
+#include <hikyuu/indicator/crt/CORR.h>
+#include <hikyuu/indicator/crt/CVAL.h>
+#include <hikyuu/indicator/crt/EMA.h>
 #include <hikyuu/indicator/crt/MA.h>
 #include <hikyuu/indicator/crt/KDATA.h>
+#include <hikyuu/indicator/crt/STDEV.h>
 #include <hikyuu/StockManager.h>
+#include "../test_config.h"
 #include "../plugin_valid.h"
 #include <algorithm>
 #include <utility>  // for std::pair
 #include <string>   // for std::to_string
 
 using namespace hku;
+
+namespace {
+
+class PythonLikeIndicatorImp : public IndicatorImp {
+public:
+    PythonLikeIndicatorImp() : IndicatorImp("PYTHON_LIKE") {
+        m_is_python_object = true;
+    }
+
+    IndicatorImpPtr _clone() override {
+        return make_shared<PythonLikeIndicatorImp>();
+    }
+};
+
+std::atomic<size_t> g_counting_indicator_calculations{0};
+
+class CountingContextIndicatorImp : public IndicatorImp {
+public:
+    CountingContextIndicatorImp() : IndicatorImp("COUNTING_CONTEXT") {
+        m_need_context = true;
+    }
+
+    void _calculate(const Indicator&) override {
+        const KData& kdata = getContext();
+        HKU_IF_RETURN(kdata.empty(), void());
+        ++g_counting_indicator_calculations;
+        _readyBuffer(kdata.size(), 1);
+        m_discard = 0;
+        auto* dst = data();
+        for (size_t i = 0; i < kdata.size(); ++i) {
+            dst[i] = static_cast<price_t>(i);
+        }
+    }
+
+    IndicatorImpPtr _clone() override {
+        return make_shared<CountingContextIndicatorImp>();
+    }
+};
+
+}  // namespace
 
 /**
  * @defgroup test_FactorSet test_FactorSet
@@ -1139,6 +1189,180 @@ TEST_CASE("test_FactorSet_getValues_result_correctness") {
                 CHECK_GT(ind_true.size(), 0);
             }
         }
+    }
+}
+
+TEST_CASE("test_CompiledFactorPlan_executor_reuse") {
+    StockManager& sm = StockManager::instance();
+    Stock stock1 = sm.getStock("sh000001");
+    Stock stock2 = sm.getStock("sz000001");
+    REQUIRE_FALSE(stock1.isNull());
+    REQUIRE_FALSE(stock2.isNull());
+
+    KData k1 = stock1.getKData(KQuery(0, 30, KQuery::DAY));
+    KData k2 = stock2.getKData(KQuery(0, 300, KQuery::DAY));
+    REQUIRE_FALSE(k1.empty());
+    REQUIRE_FALSE(k2.empty());
+
+    IndicatorList formulas{
+      MA(CLOSE(), 5),
+      EMA(CLOSE(), 13),
+      STDEV(CLOSE(), 10),
+      MA(CLOSE(), IndParam(CVAL(CLOSE(), 7))),
+      CORR(CLOSE(), OPEN(), 10),
+    };
+    detail::CompiledFactorPlan plan(formulas);
+    REQUIRE_UNARY(plan.isReusable());
+    auto executor = plan.createExecutor();
+
+    auto check_one = [&](const KData& kdata) {
+        IndicatorList result = executor.executeValues(kdata);
+        REQUIRE_EQ(result.size(), formulas.size());
+        for (size_t i = 0; i < formulas.size(); ++i) {
+            check_indicator(result[i], formulas[i](kdata).getResult(0));
+        }
+    };
+
+    // Exercise buffer growth, shrinkage, and returning to the original stock on one executor.
+    check_one(k1);
+    Indicator preserved = executor.executeValues(k1)[0];
+    check_one(k2);
+    check_indicator(preserved, formulas[0](k1).getResult(0));
+    check_one(k1);
+
+    IndicatorList shrunk = executor.executeValues(k1);
+    for (const auto& value : shrunk) {
+        CHECK_EQ(value.size(), k1.size());
+    }
+}
+
+TEST_CASE("test_CompiledFactorPlan_fallback_eligibility") {
+    detail::CompiledFactorPlan context_plan({hku::CONTEXT(CLOSE())});
+    CHECK_FALSE(context_plan.isReusable());
+
+    Indicator python_like(make_shared<PythonLikeIndicatorImp>());
+    detail::CompiledFactorPlan python_plan({python_like});
+    CHECK_FALSE(python_plan.isReusable());
+
+    Indicator custom(make_shared<CountingContextIndicatorImp>());
+    custom.getImp()->supportBatchReuse(false);
+    detail::CompiledFactorPlan custom_plan({custom});
+    CHECK_FALSE(custom_plan.isReusable());
+
+    detail::CompiledFactorPlan empty_data_plan({MA(CLOSE(), 5)});
+    REQUIRE_UNARY(empty_data_plan.isReusable());
+    auto executor = empty_data_plan.createExecutor();
+    IndicatorList empty_values = executor.executeValues(KData());
+    REQUIRE_EQ(empty_values.size(), 1);
+    CHECK_UNARY(empty_values[0].empty());
+}
+
+TEST_CASE("test_CompiledFactorPlan_root_cse") {
+    StockManager& sm = StockManager::instance();
+    KData k1 = sm.getStock("sh000001").getKData(KQuery(0, 30, KQuery::DAY));
+    KData k2 = sm.getStock("sz000001").getKData(KQuery(0, 30, KQuery::DAY));
+    REQUIRE_FALSE(k1.empty());
+    REQUIRE_FALSE(k2.empty());
+
+    Indicator formula(make_shared<CountingContextIndicatorImp>());
+    detail::CompiledFactorPlan plan({formula, formula, formula + 1.0});
+    REQUIRE_UNARY(plan.isReusable());
+    auto executor = plan.createExecutor();
+
+    g_counting_indicator_calculations = 0;
+    IndicatorList first = executor.executeValues(k1);
+    REQUIRE_EQ(first.size(), 3);
+    CHECK_EQ(g_counting_indicator_calculations.load(), 1);
+    CHECK_NE(first[0].getImp().get(), first[1].getImp().get());
+    check_indicator(first[0], first[1]);
+    check_indicator(first[0] + 1.0, first[2]);
+
+    IndicatorList second = executor.executeValues(k2);
+    REQUIRE_EQ(second.size(), 3);
+    CHECK_EQ(g_counting_indicator_calculations.load(), 2);
+    check_indicator(second[0], second[1]);
+    check_indicator(second[0] + 1.0, second[2]);
+}
+
+TEST_CASE("test_FactorSet_compiled_values_match_legacy") {
+    StockManager& sm = StockManager::instance();
+    StockList stocks{sm.getStock("sh000001"), sm.getStock("sz000001")};
+    REQUIRE_FALSE(stocks[0].isNull());
+    REQUIRE_FALSE(stocks[1].isNull());
+
+    KQuery query(0, 120, KQuery::DAY);
+    FactorSet factorset("COMPILED_VALUES", KQuery::DAY);
+    factorset.add("MA5", MA(CLOSE(), 5));
+    factorset.add("EMA13", EMA(CLOSE(), 13));
+    factorset.add("STDEV20", STDEV(CLOSE(), 20));
+
+    auto values = factorset.getValues(stocks, query, false, false, true);
+    REQUIRE_EQ(values.size(), stocks.size());
+    for (size_t si = 0; si < stocks.size(); ++si) {
+        KData kdata = stocks[si].getKData(query);
+        REQUIRE_EQ(values[si].size(), factorset.size());
+        for (size_t fi = 0; fi < factorset.size(); ++fi) {
+            CAPTURE(si);
+            CAPTURE(fi);
+            CAPTURE(factorset[fi].name());
+            Indicator expected = factorset[fi].formula()(kdata).getResult(0);
+            check_indicator(values[si][fi], expected);
+        }
+    }
+
+    DatetimeList dates = sm.getTradingCalendar(query);
+    auto aligned = factorset.getValues(stocks, query, true, false, true, false, dates);
+    REQUIRE_EQ(aligned.size(), stocks.size());
+    for (size_t si = 0; si < stocks.size(); ++si) {
+        KData kdata = stocks[si].getKData(query);
+        for (size_t fi = 0; fi < factorset.size(); ++fi) {
+            CAPTURE(si);
+            CAPTURE(fi);
+            CAPTURE(factorset[fi].name());
+            Indicator expected = ALIGN(factorset[fi].formula(), dates, false)(kdata).getResult(0);
+            check_indicator(aligned[si][fi], expected);
+        }
+    }
+}
+
+TEST_CASE("test_FactorSet_formula_results_keep_independent_graphs") {
+    Stock stock = StockManager::instance().getStock("sh000001");
+    REQUIRE_FALSE(stock.isNull());
+
+    Indicator shared_formula = MA(CLOSE(), 5);
+    FactorSet factorset("FORMULA_RESULTS", KQuery::DAY);
+    factorset.add("FIRST", shared_formula);
+    factorset.add("SECOND", shared_formula);
+
+    auto result = factorset.getValues({stock}, KQuery(0, 30, KQuery::DAY), false, false, false);
+    REQUIRE_EQ(result.size(), 1);
+    REQUIRE_EQ(result[0].size(), 2);
+    CHECK_NE(result[0][0].getImp().get(), result[0][1].getImp().get());
+    check_indicator(result[0][0], result[0][1]);
+}
+
+TEST_CASE("test_FactorSet_compiled_path_nested_invocation") {
+    Stock stock = StockManager::instance().getStock("sh000001");
+    REQUIRE_FALSE(stock.isNull());
+
+    FactorSet factorset("NESTED_COMPILED", KQuery::DAY);
+    factorset.add("MA5", MA(CLOSE(), 5));
+    factorset.add("EMA13", EMA(CLOSE(), 13));
+
+    vector<std::future<vector<IndicatorList>>> futures;
+    for (size_t i = 0; i < 4; ++i) {
+        futures.emplace_back(global_submit_task([factorset, stock]() {
+            return factorset.getValues({stock}, KQuery(0, 30, KQuery::DAY), false, false, true);
+        }));
+    }
+
+    for (auto& future : futures) {
+        global_wait_task(future);
+        auto result = future.get();
+        REQUIRE_EQ(result.size(), 1);
+        REQUIRE_EQ(result[0].size(), 2);
+        CHECK_EQ(result[0][0].size(), 30);
+        CHECK_EQ(result[0][1].size(), 30);
     }
 }
 

--- a/hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp
@@ -18,6 +18,7 @@
 #include <hikyuu/indicator/crt/EMA.h>
 #include <hikyuu/indicator/crt/MA.h>
 #include <hikyuu/indicator/crt/KDATA.h>
+#include <hikyuu/indicator/crt/REF.h>
 #include <hikyuu/indicator/crt/STDEV.h>
 #include <hikyuu/StockManager.h>
 #include "../test_config.h"
@@ -42,6 +43,7 @@ public:
 };
 
 std::atomic<size_t> g_counting_indicator_calculations{0};
+std::atomic<size_t> g_counting_indicator_clones{0};
 
 class CountingContextIndicatorImp : public IndicatorImp {
 public:
@@ -62,6 +64,7 @@ public:
     }
 
     IndicatorImpPtr _clone() override {
+        ++g_counting_indicator_clones;
         return make_shared<CountingContextIndicatorImp>();
     }
 };
@@ -1211,6 +1214,10 @@ TEST_CASE("test_CompiledFactorPlan_executor_reuse") {
       MA(CLOSE(), IndParam(CVAL(CLOSE(), 7))),
       CORR(CLOSE(), OPEN(), 10),
     };
+    Indicator low = LOW();
+    formulas.emplace_back(CORR(MA(VOL(), 20), low, 5) + (HIGH() + low) / 2.0 - CLOSE());
+    Indicator open_close = OPEN() - CLOSE();
+    formulas.emplace_back(CORR(REF(open_close, 1), CLOSE(), 200) + open_close);
     detail::CompiledFactorPlan plan(formulas);
     REQUIRE_UNARY(plan.isReusable());
     auto executor = plan.createExecutor();
@@ -1234,6 +1241,16 @@ TEST_CASE("test_CompiledFactorPlan_executor_reuse") {
     for (const auto& value : shrunk) {
         CHECK_EQ(value.size(), k1.size());
     }
+}
+
+TEST_CASE("test_CompiledFactorPlan_preserves_shared_formula_dag") {
+    Indicator shared(make_shared<CountingContextIndicatorImp>());
+    Indicator repeated = shared + shared;
+
+    g_counting_indicator_clones = 0;
+    detail::CompiledFactorPlan plan({repeated});
+    REQUIRE_UNARY(plan.isReusable());
+    CHECK_EQ(g_counting_indicator_clones.load(), 1);
 }
 
 TEST_CASE("test_CompiledFactorPlan_fallback_eligibility") {
@@ -1342,8 +1359,12 @@ TEST_CASE("test_FactorSet_formula_results_keep_independent_graphs") {
 }
 
 TEST_CASE("test_FactorSet_compiled_path_nested_invocation") {
-    Stock stock = StockManager::instance().getStock("sh000001");
-    REQUIRE_FALSE(stock.isNull());
+    Stock stock1 = StockManager::instance().getStock("sh000001");
+    Stock stock2 = StockManager::instance().getStock("sz000001");
+    REQUIRE_FALSE(stock1.isNull());
+    REQUIRE_FALSE(stock2.isNull());
+    StockList stocks{stock1, stock2};
+    KQuery query(0, 30, KQuery::DAY);
 
     FactorSet factorset("NESTED_COMPILED", KQuery::DAY);
     factorset.add("MA5", MA(CLOSE(), 5));
@@ -1351,18 +1372,21 @@ TEST_CASE("test_FactorSet_compiled_path_nested_invocation") {
 
     vector<std::future<vector<IndicatorList>>> futures;
     for (size_t i = 0; i < 4; ++i) {
-        futures.emplace_back(global_submit_task([factorset, stock]() {
-            return factorset.getValues({stock}, KQuery(0, 30, KQuery::DAY), false, false, true);
+        futures.emplace_back(global_submit_task([factorset, stocks, query]() {
+            return factorset.getValues(stocks, query, false, false, true);
         }));
     }
 
     for (auto& future : futures) {
         global_wait_task(future);
         auto result = future.get();
-        REQUIRE_EQ(result.size(), 1);
-        REQUIRE_EQ(result[0].size(), 2);
-        CHECK_EQ(result[0][0].size(), 30);
-        CHECK_EQ(result[0][1].size(), 30);
+        REQUIRE_EQ(result.size(), stocks.size());
+        for (size_t i = 0; i < stocks.size(); ++i) {
+            REQUIRE_EQ(result[i].size(), 2);
+            KData kdata = stocks[i].getKData(query);
+            check_indicator(result[i][0], MA(CLOSE(), 5)(kdata).getResult(0));
+            check_indicator(result[i][1], EMA(CLOSE(), 13)(kdata).getResult(0));
+        }
     }
 }
 

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp
@@ -57,6 +57,22 @@ TEST_CASE("test_indicator_alike") {
     CHECK_UNARY(data1.alike(data2));
 }
 
+TEST_CASE("test_indicator_alike_dynamic_parameters") {
+    Indicator ma5 = MA(CLOSE(), IndParam(CVAL(CLOSE(), 5)));
+    Indicator ma10 = MA(CLOSE(), IndParam(CVAL(CLOSE(), 10)));
+    Indicator ma5_copy = MA(CLOSE(), IndParam(CVAL(CLOSE(), 5)));
+
+    CHECK_FALSE(ma5.alike(ma10));
+    CHECK_UNARY(ma5.alike(ma5_copy));
+
+    Indicator corr_close = CORR(CLOSE(), OPEN(), 10);
+    Indicator corr_high = CORR(HIGH(), OPEN(), 10);
+    Indicator corr_close_copy = CORR(CLOSE(), OPEN(), 10);
+
+    CHECK_FALSE(corr_close.alike(corr_high));
+    CHECK_UNARY(corr_close.alike(corr_close_copy));
+}
+
 /** @par 检测点 */
 TEST_CASE("test_operator_add") {
     /** @arg 正常相加*/


### PR DESCRIPTION

## 问题概述

`FactorSet::getValues` 当前按因子并行，并由每个 `Factor` 再按股票计算：

```text
FactorSet
  -> parallel for each factor
      -> Factor::getValues
          -> parallel for each stock
              -> clone/bind/calculate formula
```

在 Alpha101 等多因子批量场景中，不同公式会重复引用 `CLOSE`、`OPEN`、`VOL`、
`AMO` 等行情叶子，以及相同的中间指标。旧路径无法在因子之间共享这些节点，且每个
`(factor, stock)` 组合都需要重新构造、绑定和计算公式图。

该结构带来三类固定开销：

1. 相同叶子和相同子表达式在多个因子中重复计算。
2. 每只股票重复克隆和绑定完整公式对象图。
3. 因子维与股票维嵌套使用全局线程池，存在过度调度和嵌套等待风险。

本 PR 为 `FactorSet` 增加内部批量执行计划：将整组公式编译为共享 DAG，每个任务范围
使用一个可复用 executor 连续计算多只股票。现有 `FactorSet::getValues` API 和返回布局
保持不变。

## 根因分析

### 1. 调度单位与共享边界不匹配

旧实现以单个因子为最外层调度单位：

```cpp
global_parallel_for_index_void(0, factor_total, [&](size_t i) {
    IndicatorList factor_values =
      factors[i].getValues(stocks, query, align, fill_null, tovalue, false, align_dates);
});
```

`Factor::getValues` 内部再遍历股票。因子之间没有共同的执行上下文，因此无法共享公式
叶子和中间节点；外层因子任务进入内层股票并行时还会再次使用全局线程池。

### 2. Indicator 同时承载公式定义和运行状态

现有 Indicator 图中同时包含：

- 公式结构、参数和输入关系；
- 当前 `KData` context；
- `discard`、计算标志和结果 buffer；
- parent 指针及动态 Indicator 参数。

直接跨股票共享同一对象图会污染运行状态；为每个 `(factor, stock)` 完整克隆又会重复
支付对象图成本。优化需要把稳定的公式模板与每个执行任务的可变状态隔离。

### 3. 原有 `IndicatorImp::alike` 无法完整描述结构等价

原实现的动态参数迭代器从 `end()` 开始，无法正确比较 `m_ind_params`；普通子节点比较
也没有区分“仅一侧存在子节点”的情况。若直接用于公共子表达式消除，可能错误合并
动态参数或输入结构不同的节点。

## 优化方案

### 1. 新增内部 `CompiledFactorPlan`

`CompiledFactorPlan` 接收本批次的全部公式，并完成以下步骤：

1. 检查整张图是否支持安全的 batch reuse。
2. 用一个跨全部 root 共享的 `CloneMap` 克隆公式模板，保留原 DAG 拓扑，并清除与历史
   context 绑定的运行状态。
3. 递归覆盖 root、普通 children、动态 Indicator 参数和可见内部节点。
4. 使用 `IndicatorImp::alike` 对结构等价节点做 canonicalization，形成共享 DAG。
5. 重新规范化 parent 指针；被多个父节点共享的节点不保留单一 parent。

Plan 只保存无股票状态的 Master DAG，不直接参与并发计算。

### 2. 每个股票任务范围复用一个 executor

`CompiledFactorPlan::createExecutor()` 从 Master DAG 克隆一份独立执行图。`FactorSet` 按
股票范围提交任务，每个范围创建一个 executor，并连续用于该范围内的所有股票：

```text
all factor formulas
  -> CompiledFactorPlan (once per getValues call)
      -> executor for range 1 -> stock 1, stock 2, ...
      -> executor for range 2 -> stock N, stock N+1, ...
```

每轮执行会统一重新绑定 `KData`、重置计算状态，并用同一个 visited set 遍历所有 root、
普通 children 和动态参数。共享节点每轮只准备一次；动态参数在其父指标计算前完成计算。

结果通过 `getResult(0)` 返回独立数值 buffer，后续股票复用 executor 不会修改已返回结果。

### 3. 在编译前保留 ALIGN 时序语义

对齐操作必须在结果仍携带 `KData` 日期上下文时执行。快速路径在构造 Plan 前将公式包装
为：

```cpp
ALIGN(factor.formula(), dates, fill_null)
```

而不是在 `getResult(0)` 后对纯数值结果再做 ALIGN。这样可保持股票日历存在偏移时与
legacy 路径一致的日期映射和 `discard`。

### 4. 收敛线程池层级

快速路径只按股票范围向全局线程池提交任务，不再按因子和股票双层并行。每个 range
独占一个 executor；即使调用来自全局线程池 worker，也统一使用框架现有的非阻塞等待和
工作窃取机制完成嵌套任务，不再手工降级为串行。

### 5. 保守 fallback

以下情况继续走原有实现：

| 场景 | 处理 |
|------|------|
| `tovalue=false` | 保留 legacy，确保返回公式图彼此独立 |
| ClickHouse driver | 保留现有插件批量路径 |
| Python Indicator | 回退，C++ executor 无法重置任意 Python 状态 |
| `CONTEXT` | 回退，其私有图具有独立 context 绑定语义 |
| 自定义有状态 C++ Indicator | 可调用 `supportBatchReuse(false)` 主动回退 |

`supportBatchReuse` 是新增的 C++ opt-out 接口；已有 `FactorSet::getValues` 调用签名不变。

### 6. 修正 `IndicatorImp::alike`

本 PR 同时修正结构等价判断：

1. 动态参数从双方 `m_ind_params.cbegin()` 开始逐项比较。
2. `selfAlike` 仅负责当前节点自身；非叶节点仍继续比较动态参数和 children。
3. 普通 children 的存在性和递归结构必须完全一致。

该修正确保参数值不同或输入结构不同的节点不会被 CSE 错误合并。

此外，`inner_repeatALikeNodes` 会跳过没有 generic parent edge 的私有派生图 root，例如
`Indicator2InImp::m_ref_ind`。这类节点不能通过 `m_left/m_right/m_three` 重连；过滤它们
既避免越权改写，也消除了 Alpha101 028/037 构造和计算时的 LOW/CLOSE 假错误日志。
本 PR 没有调整 KType pass 顺序。

## 验证

### 编译

- 环境：Windows 11 x64、Visual Studio 2022、MSVC、xmake release。
- 本地验证按 `DEVELOPMENT_WORKFLOW.md` 使用 MSVC 编译桥接配置完成；桥接配置未进入本 PR。
- 构建命令：`xmake -j14 -b hikyuu`、`xmake -j14 -b unit-test`。
- 回归命令：`build/release/windows/x64/lib/unit-test.exe --test-case-exclude=*benchmark*`。
- 构建目标：`hikyuu.dll`、`unit-test.exe`。
- 结果：两项目标均编译成功。
- 验证产物：`build/release/windows/x64/lib/{hikyuu.dll,unit-test.exe}`。

### 功能验证

| 测试 | 覆盖点 | 结果 |
|------|--------|------|
| `test_CompiledFactorPlan_executor_reuse` | 同 executor 按 30 -> 300 -> 30 bars 扩容、缩容、回到原股票；覆盖 Alpha101 028/037 类私有引用图并逐值对齐 legacy | PASS |
| `test_CompiledFactorPlan_preserves_shared_formula_dag` | 跨 root 使用共享 `CloneMap`，`shared + shared` 只克隆一次 | PASS |
| `test_CompiledFactorPlan_root_cse` | root 与子图 CSE；同一股票共享节点只计算一次 | PASS |
| `test_CompiledFactorPlan_fallback_eligibility` | `CONTEXT`、Python、自定义 opt-out、空 KData | PASS |
| `test_FactorSet_compiled_values_match_legacy` | 非对齐及 ALIGN 输出逐值、size、discard 对齐 legacy | PASS |
| `test_FactorSet_formula_results_keep_independent_graphs` | `tovalue=false` 不暴露共享执行图 | PASS |
| `test_FactorSet_compiled_path_nested_invocation` | 4 个外层 worker 任务各自嵌套双股票 range 调度，MA/EMA 逐值对齐 legacy | PASS |
| `test_indicator_alike_dynamic_parameters` | 动态参数值及 CORR 输入图的结构等价判断 | PASS |

定向回归：

| filter | cases | assertions | 结果 |
|--------|------:|-----------:|------|
| `test_CompiledFactorPlan*,test_FactorSet_compiled*` | 2 | 1996 | PASS |

### 完整回归测试

```text
test cases:    776 | 776 passed | 0 failed | 0 skipped
assertions: 208452 | 208452 passed | 0 failed
```

### 静态检查

- `clang-format --dry-run --Werror`：7 个改动文件通过。
- `git diff --check`：通过。

## 改动范围

| 文件 | 类型 | 说明 |
|------|------|------|
| `hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.h` | 新增 | Master DAG 与 executor 内部接口 |
| `hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp` | 新增 | 克隆、CSE、状态准备、执行器复用 |
| `hikyuu_cpp/hikyuu/factor/FactorSet.cpp` | 修改 | 接入 value-only 快速路径和单层股票范围调度 |
| `hikyuu_cpp/hikyuu/indicator/IndicatorImp.h` | 修改 | batch reuse opt-out 与 Plan 内部访问 |
| `hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp` | 修改 | 修正 `alike` 结构比较 |
| `hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp` | 修改 | Plan、复用、fallback、兼容性及线程测试 |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp` | 修改 | 动态参数和多输入结构等价测试 |

合计：7 文件，+783 / -31；分为两个独立提交：

- `533299fb perf(factor): reuse compiled factor execution plans`
- `38193c07 perf(factor): fix compiled plan scheduling and DAG cloning`

## API 与兼容性

现有 C++ 和 Python 调用代码不需要修改。`FactorSet::getValues`、
`FactorSet::getAllValues` 的参数和返回顺序都保持不变，结果仍按 `[股票][因子]` 排列。

优化只在调用方要求返回最终数值（`tovalue=true`）时启用。返回公式对象、使用
ClickHouse 或遇到不适合复用的自定义指标时，仍走原来的计算路径。已有自定义 C++ 指标
无需修改；只有内部保存额外运行状态的指标，才需要通过 `supportBatchReuse(false)`
明确关闭复用。

## 性能影响

旧实现会为每个“因子 x 股票”组合分别准备和计算公式。新实现先统一整理整组因子，再让
每个线程连续处理一批股票。这样，同一只股票中重复出现的 `CLOSE`、`VOL` 等输入和相同
子公式只需计算一次，计算过程中使用的临时内存也可以重复利用，同时减少了线程池中的
零散任务数量。指标公式和数值算法本身没有改变。

### Python 真实负载 A/B

基准使用同一 uv 环境、数据库和 Alpha101 公式代码，关闭运行日志，只替换 Hikyuu 2.8.1
二进制。旧版为 PyPI 预编译包 `202607100146`，DLL SHA256 为
`90b930d536bcab59ee10481f26bba013fca15f23e4b7f4f7f83e9de4a1e8092e`；新版为本分支的
MSVC Release 构建 `202607151914`，DLL SHA256 为
`b33b40a1923473ca817fcbb4c07cf06cd99ed75a345291b5f0d709fb7e6fe433`。

负载：当前沪深300成分股 N=287、Alpha101 全部 K=62、`Query(-500)` T=500，调用
`FactorSet.get_values(..., align=False, fill_null=False, tovalue=True)`。

| 版本 | 第 1 轮 | 第 2 轮 | 第 3 轮 | 第 4 轮 | 第 5 轮 | 中位数 |
|------|---------:|---------:|---------:|---------:|---------:|-------:|
| PyPI 2.8.1 | 2.522452 秒 | 0.627337 秒 | 0.558972 秒 | 0.628818 秒 | 0.481226 秒 | 0.627337 秒 |
| 本 PR | 1.102770 秒 | 0.319536 秒 | 0.446804 秒 | 0.431838 秒 | 0.523828 秒 | 0.446804 秒 |

5 轮中位数耗时降低 28.8%。另以反向顺序启动独立进程各测一次，新版为 1.179335 秒，
旧版为 1.574363 秒，耗时降低 25.1%。

两边结果尺寸均为 N287 x K62 x T500，有限值抽样校验和均为
`-22123004.648513742`。该结果只代表上述机器和负载，不作为其他因子规模或数据环境的
通用加速倍数。

## 已知局限

1. **每次调用都会重新准备执行计划**：`FactorSet::getValues` 暂不缓存上一次生成的 Plan。
   当前 Alpha101 基准已包含这部分耗时；如果以后一次计算包含更多、更复杂的因子，准备时间
   可能变得明显，届时可增加 Plan 缓存和更快的公式去重方式。
2. **少数指标内部的公式暂时无法共享**：`Indicator2InImp` 等指标会把部分输入公式保存在
   自己的私有成员中。当前实现仍会正确计算这些公式，但不能像普通子公式一样在多个因子间
   复用，因此这部分仍有进一步优化空间，不影响计算结果。