### PR TITLE
fix(indicator): compiled factor plan review follow-ups (#493)

### DIFF
--- a/hikyuu_cpp/hikyuu/factor/FactorSet.cpp
+++ b/hikyuu_cpp/hikyuu/factor/FactorSet.cpp
@@ -240,6 +240,11 @@ vector<IndicatorList> FactorSet::getValues(const StockList& stocks, const KQuery
                 return executor.executeValues(kdata);
             };
 
+            // 这里直接向全局线程池 submit 范围任务，且有外层调用者自身就在 work 线程里 submit
+            // 本函数时（嵌套调用）的可能。`wait_for_all_non_blocking` 必须支持在等待期间
+            // work-steal 已提交的子任务（否则当池被外层任务占满时会死锁：外层等待本任务、
+            // 本任务等待子任务、却没有空闲 worker 去执行子任务）。修改这一段前请确认
+            // `GlobalStealThreadPool` 的 non_blocking 等待确有 steal 语义。
             auto* task_group = get_global_task_group();
             HKU_ASSERT(task_group);
             auto ranges = parallelIndexRange(0, stk_total, task_group->worker_num());

--- a/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
+++ b/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
@@ -1,6 +1,9 @@
 /*
  *  Copyright (c) 2026 hikyuu.org
  *
+ *  Created on: 2026-07-15
+ *      Author: woleigegg
+ *
  *  Internal compiled execution plan for stock-local factor formulas.
  */
 

--- a/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.h
+++ b/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.h
@@ -1,6 +1,9 @@
 /*
  *  Copyright (c) 2026 hikyuu.org
  *
+ *  Created on: 2026-07-15
+ *      Author: woleigegg
+ *
  *  Internal compiled execution plan for stock-local factor formulas.
  */
 

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -927,6 +927,14 @@ Indicator IndicatorImp::calculate() {
                     _calculate(Indicator());
                 }
             } else {
+                // 动态周期叶子没有右子节点驱动 buffer 定长。当执行器跨股票重绑 context 时，
+                // 空输入会让 _dyn_calculate 在 total == 0 处提前返回而完全不触碰 buffer，
+                // 导致上一只股票的数据与长度残留在 buffer 中（脏缓冲区）。这里在调用前按
+                // 当前 context 长度预尺寸并 null 填充 buffer，使得即便 _dyn_calculate 什么都不写，
+                // size()/data() 也能返回正确（可能更短）的长度。
+                if (isNeedContext()) {
+                    _readyBuffer(getContext().size(), m_result_num);
+                }
                 _dyn_calculate(Indicator());
             }
             break;
@@ -1977,16 +1985,18 @@ bool IndicatorImp::alike(const IndicatorImp &other) const {
                     m_ind_params.size() != other.m_ind_params.size() || m_params != other.m_params,
                   false);
 
-    if (needSelfAlikeCompare()) {
-        HKU_IF_RETURN(!selfAlike(other), false);
-        HKU_IF_RETURN(isLeaf(), true);
-    }
-
     auto iter1 = m_ind_params.cbegin();
     auto iter2 = other.m_ind_params.cbegin();
     for (; iter1 != m_ind_params.cend() && iter2 != other.m_ind_params.cend(); ++iter1, ++iter2) {
         HKU_IF_RETURN(iter1->first != iter2->first, false);
         HKU_IF_RETURN(!iter1->second->alike(*(iter2->second)), false);
+    }
+
+    if (needSelfAlikeCompare()) {
+        HKU_IF_RETURN(!selfAlike(other), false);
+        // Special leaves use structural identity so an unevaluated operator template (such as
+        // CVAL(value)) can match a calculated input without comparing runtime buffers.
+        HKU_IF_RETURN(isLeaf(), true);
     }
 
     if (isLeaf() && other.isLeaf()) {

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
@@ -152,10 +152,16 @@ public:
     bool isPythonObject() const noexcept;
 
     /**
-     * Whether this implementation can be fully recalculated on a reusable batch executor.
-
-     * * Custom C++ indicators that retain state outside IndicatorImp buffers should opt out.
- */
+     * 该实现是否可在可复用的批处理执行器上被反复重算。
+     *
+     * 默认放行（非 Python 实现、且未显式置 `_support_batch_reuse=false` 都视为可复用）。
+     * 参与复用意味着同一节点的计算图会被 `CompiledFactorPlan` 跨股票反复重绑 context
+     * 并重算，因此自定义 C++ 指标必须满足：除 IndicatorImp 自身的 result buffer 与
+     * `m_params/m_ind_params` 外，不持有任何跨股票会残留的成员状态（如缓存统计量、可变
+     * 缓冲、上次输入依赖的中间结果等）。凡是会在 `_calculate`/`_dyn_calculate` 外部保留
+     * 上述状态、或无法通过 `scrubTemplateNode` 重置干净的实现，都应在构造时调用
+     * `supportBatchReuse(false)` 主动退出快速路径，回退到旧行为。
+     */
     bool supportBatchReuse() const;
 
     void supportBatchReuse(bool enable);

--- a/hikyuu_cpp/hikyuu/indicator/imp/IFactor.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IFactor.cpp
@@ -34,14 +34,15 @@ IndicatorImpPtr IFactor::_clone() {
 }
 
 bool IFactor::selfAlike(const IndicatorImp& other) const noexcept {
-    // 设计意图：Factor 仅通过名字判断是否相同（见 Factor.h 文档），故意不比较公式内容。
-    // 因此两个 FACTOR 节点只要名字相同就会被 CompiledFactorPlan 当作同一节点做 CSE 合并。
-    // 上游 FactorSet::add 已通过 nameIndexMap 按名字去重（后加入者覆盖先加入者），
-    // 所以结构良好的 FactorSet 不会把"同名不同公式"的两个因子同时喂进 compiled 路径。
-    // 下面的 dynamic_cast 保证类型安全：非 IFactor 节点永远不会被判定为等价。
+    // Factor 以“名字 + K线类型”作为唯一标识（见 Factor.h 文档），故意不比较公式内容。
+    // 因此两个 FACTOR 节点仅在名字和 K线类型都相同时，才会被 CompiledFactorPlan
+    // 当作同一节点做 CSE 合并。上游 FactorSet::add 已校验 K线类型并按名字去重
+    //（后加入者覆盖先加入者），所以结构良好的 FactorSet 不会把“标识相同但公式不同”
+    // 的两个因子同时喂进 compiled 路径。dynamic_cast 保证非 IFactor 节点不会判等。
     const auto* other_ctx = dynamic_cast<const IFactor*>(&other);
     HKU_IF_RETURN(other_ctx == nullptr, false);
-    return m_factor.name() == other_ctx->m_factor.name();
+    return m_factor.name() == other_ctx->m_factor.name() &&
+           m_factor.ktype() == other_ctx->m_factor.ktype();
 }
 
 void IFactor::_calculate(const Indicator& data) {

--- a/hikyuu_cpp/hikyuu/indicator/imp/IFactor.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/imp/IFactor.cpp
@@ -15,10 +15,12 @@ namespace hku {
 
 IFactor::IFactor() : IndicatorImp("FACTOR", 1) {
     m_need_context = true;
+    m_need_self_alike_compare = true;
 }
 
 IFactor::IFactor(const Factor& factor) : IndicatorImp("FACTOR", 1), m_factor(factor) {
     m_need_context = true;
+    m_need_self_alike_compare = true;
 }
 
 IFactor::~IFactor() {}
@@ -32,6 +34,11 @@ IndicatorImpPtr IFactor::_clone() {
 }
 
 bool IFactor::selfAlike(const IndicatorImp& other) const noexcept {
+    // 设计意图：Factor 仅通过名字判断是否相同（见 Factor.h 文档），故意不比较公式内容。
+    // 因此两个 FACTOR 节点只要名字相同就会被 CompiledFactorPlan 当作同一节点做 CSE 合并。
+    // 上游 FactorSet::add 已通过 nameIndexMap 按名字去重（后加入者覆盖先加入者），
+    // 所以结构良好的 FactorSet 不会把"同名不同公式"的两个因子同时喂进 compiled 路径。
+    // 下面的 dynamic_cast 保证类型安全：非 IFactor 节点永远不会被判定为等价。
     const auto* other_ctx = dynamic_cast<const IFactor*>(&other);
     HKU_IF_RETURN(other_ctx == nullptr, false);
     return m_factor.name() == other_ctx->m_factor.name();

--- a/hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp
@@ -16,6 +16,7 @@
 #include <hikyuu/indicator/crt/CORR.h>
 #include <hikyuu/indicator/crt/CVAL.h>
 #include <hikyuu/indicator/crt/EMA.h>
+#include <hikyuu/indicator/crt/FACTOR.h>
 #include <hikyuu/indicator/crt/MA.h>
 #include <hikyuu/indicator/crt/KDATA.h>
 #include <hikyuu/indicator/crt/REF.h>
@@ -1340,6 +1341,36 @@ TEST_CASE("test_FactorSet_compiled_values_match_legacy") {
             check_indicator(aligned[si][fi], expected);
         }
     }
+}
+
+TEST_CASE("test_FactorSet_compiled_values_keep_nested_factors_distinct") {
+    Stock stock = StockManager::instance().getStock("sh000001");
+    REQUIRE_FALSE(stock.isNull());
+
+    Factor close_ma5("INNER_CLOSE_MA5", MA(CLOSE(), 5), KQuery::DAY);
+    Factor high_ma3("INNER_HIGH_MA3", MA(HIGH(), 3), KQuery::DAY);
+    FactorSet factorset("NESTED_FACTORS", KQuery::DAY);
+    factorset.add("OUTER_CLOSE_MA5", FACTOR(close_ma5));
+    factorset.add("OUTER_HIGH_MA3", FACTOR(high_ma3));
+
+    KQuery query(0, 30, KQuery::DAY);
+    KData kdata = stock.getKData(query);
+    REQUIRE_FALSE(kdata.empty());
+
+    auto compiled = factorset.getValues({stock}, query, false, false, true);
+    auto legacy = factorset.getValues({stock}, query, false, false, false);
+    REQUIRE_EQ(compiled.size(), 1);
+    REQUIRE_EQ(compiled[0].size(), 2);
+    REQUIRE_EQ(legacy.size(), 1);
+    REQUIRE_EQ(legacy[0].size(), 2);
+
+    Indicator expected_close_ma5 = FACTOR(close_ma5)(kdata).getResult(0);
+    Indicator expected_high_ma3 = FACTOR(high_ma3)(kdata).getResult(0);
+    check_indicator(compiled[0][0], expected_close_ma5);
+    check_indicator(compiled[0][1], expected_high_ma3);
+    check_indicator(legacy[0][0].getResult(0), expected_close_ma5);
+    check_indicator(legacy[0][1].getResult(0), expected_high_ma3);
+    CHECK_FALSE(compiled[0][0].equal(compiled[0][1]));
 }
 
 TEST_CASE("test_FactorSet_formula_results_keep_independent_graphs") {

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_FACTOR.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_FACTOR.cpp
@@ -92,13 +92,15 @@ TEST_CASE("test_FACTOR_different_factors") {
     check_indicator(result2, ma3_result);
 }
 
-TEST_CASE("test_FACTOR_alike_uses_factor_name") {
+TEST_CASE("test_FACTOR_alike_uses_factor_identity") {
     Factor close_ma5("CLOSE_MA5", MA(CLOSE(), 5), KQuery::DAY);
     Factor high_ma3("HIGH_MA3", MA(HIGH(), 3), KQuery::DAY);
-    Factor same_name_different_formula("CLOSE_MA5", MA(HIGH(), 3), KQuery::DAY);
+    Factor same_identity_different_formula("CLOSE_MA5", MA(HIGH(), 3), KQuery::DAY);
+    Factor same_name_different_ktype("CLOSE_MA5", MA(CLOSE(), 5), KQuery::WEEK);
 
     CHECK_FALSE(FACTOR(close_ma5).alike(FACTOR(high_ma3)));
-    CHECK_UNARY(FACTOR(close_ma5).alike(FACTOR(same_name_different_formula)));
+    CHECK_UNARY(FACTOR(close_ma5).alike(FACTOR(same_identity_different_formula)));
+    CHECK_FALSE(FACTOR(close_ma5).alike(FACTOR(same_name_different_ktype)));
 }
 
 //-----------------------------------------------------------------------------

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_FACTOR.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_FACTOR.cpp
@@ -92,6 +92,15 @@ TEST_CASE("test_FACTOR_different_factors") {
     check_indicator(result2, ma3_result);
 }
 
+TEST_CASE("test_FACTOR_alike_uses_factor_name") {
+    Factor close_ma5("CLOSE_MA5", MA(CLOSE(), 5), KQuery::DAY);
+    Factor high_ma3("HIGH_MA3", MA(HIGH(), 3), KQuery::DAY);
+    Factor same_name_different_formula("CLOSE_MA5", MA(HIGH(), 3), KQuery::DAY);
+
+    CHECK_FALSE(FACTOR(close_ma5).alike(FACTOR(high_ma3)));
+    CHECK_UNARY(FACTOR(close_ma5).alike(FACTOR(same_name_different_formula)));
+}
+
 //-----------------------------------------------------------------------------
 // test export
 //-----------------------------------------------------------------------------

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp
@@ -71,6 +71,15 @@ TEST_CASE("test_indicator_alike_dynamic_parameters") {
 
     CHECK_FALSE(corr_close.alike(corr_high));
     CHECK_UNARY(corr_close.alike(corr_close_copy));
+
+    Indicator corr_open_template = CORR(OPEN(), 10);
+    Indicator corr_high_template = CORR(HIGH(), 10);
+    Indicator corr_open_template_copy = CORR(OPEN(), 10);
+
+    CHECK_FALSE(corr_open_template.alike(corr_high_template));
+    CHECK_UNARY(corr_open_template.alike(corr_open_template_copy));
+
+    CHECK_FALSE(DROPNA(CLOSE()).alike(DROPNA(CLOSE())));
 }
 
 /** @par 检测点 */


### PR DESCRIPTION
## 问题概述

本 PR 是 #493 的两条 review 意见及合并后自查问题的跟进修复，共四点：

1. `IndicatorImp::alike` 中特殊指标的 `selfAlike` + 叶子提前返回位于动态参数比较之前，
   使 `m_ind_params` 的结构比较可被绕过（review 意见一）。
2. `IFactor` 未启用 `needSelfAlikeCompare`，`FACTOR` 节点的私有公式 (`m_factor`) 不参与
   结构等价判断，CSE 无法正确区分嵌套因子节点。
3. 执行器跨股票复用时，context 驱动的动态参数叶子在 `_dyn_calculate` 提前返回的路径上
   可能残留上一只股票的 buffer（防御性修复）。
4. 新增文件缺少 Author 头（review 意见二）。

## 根因分析

### 1. `alike` 比较顺序破坏了"通用结构比较不可绕过"的不变量

#493 合入的版本：

```cpp
if (needSelfAlikeCompare()) {
    HKU_IF_RETURN(!selfAlike(other), false);
    HKU_IF_RETURN(isLeaf(), true);   // ← 在 m_ind_params 循环之前返回
}
auto iter1 = m_ind_params.cbegin();  // 动态参数比较被跳过
...
```

`selfAlike` 的语义是"只负责当前节点私有状态"，但叶子提前返回使它同时跳过了
`m_ind_params` 的递归结构比较。`alike()` 除 CSE 外还用于
`Indicator::operator()` 的 AST 裁剪（判等则直接复用操作数、丢弃算子节点）和
`inner_repeatALikeNodes` 的父指针重接，错误判等会直接改写公式图结构。

当前代码库中 `needSelfAlikeCompare() == true` 的叶子（CVAL、CONTEXT、IC 模板、FACTOR）
均不把结构输入放在 `m_ind_params`，因此该顺序缺陷**无现存可触发实例**；但一旦出现
"特殊叶子 + 动态指标参数"的组合即会错误合并，属于必须修正的顺序问题。

### 2. `IFactor` 缺少结构等价语义

`IFactor` 把因子公式保存在私有成员 `m_factor` 中，通用 `alike` 走不到它。两个
FACTOR 模板节点（未计算、buffer 均为空）会被叶子 buffer 比较误判为等价，嵌套使用
不同因子时可能被 CSE 错误合并。

### 3. 执行器复用时动态参数叶子的 buffer 残留（防御性）

`FactorPlanExecutor` 逐股票复用执行图，`prepareNode` 只重置计算标志与 `m_discard`，
不清空 result buffer。`LEAF + 非空 m_ind_params` 分支调用
`_dyn_calculate(Indicator())`；对 `isNeedContext()` 的叶子，若未来某实现的
`_dyn_calculate` 在新 context 更短/为空时提前返回且不触碰 buffer，`size()`/`data()`
将返回上一只股票的残留数据。

经全量排查，当前代码库中 `m_need_context = true` 的类与带 `setIndParam` 的类交集为空，
即**该路径现无命中实例**；本 PR 仅作防御性预尺寸，守卫限定 `isNeedContext()`，
不改变任何现有指标的行为。

## 修复方案

1. **`alike` 比较重排**：`m_ind_params` 递归比较前移到特殊分支之前。所有节点先完成
   动态参数结构比较，再做 `selfAlike`；特殊叶子只在此时提前返回（仅跳过运行时
   buffer 比较，保留模板与已计算输入的匹配能力）；非叶特殊指标在 `selfAlike` 之后
   继续走 children 比较。
2. **`IFactor` 启用 self-alike**：按 Factor 的唯一标识（`name + ktype`）判等，
   与 `Factor.h` 的定义一致；`FactorSet::add` 已校验 K线类型并按名去重，
   `dynamic_cast` 保证跨类型安全。设计前提已在注释中写明。
3. **防御性 buffer 预尺寸**：`LEAF + 动态参数` 分支中，`isNeedContext()` 节点在
   `_dyn_calculate` 前按 `getContext().size()` 调用 `_readyBuffer` 并 null 填充，
   保证提前返回路径下 `size()` 仍正确。
4. **文档与头文件**：`supportBatchReuse` 补充批复用契约（何种自定义指标必须
   opt-out）；`FactorSet` 补充嵌套调用依赖 work-stealing 等待的注释；
   `CompiledFactorPlan.h/.cpp` 补充 Author 头。

## 验证

### 编译

- 环境：Windows 11 x64、Visual Studio 2022、MSVC、xmake release。
- `xmake -j14 -b unit-test`：编译成功。

### 功能验证

| 测试 | 覆盖点 | 结果 |
|------|--------|------|
| `test_indicator_alike_dynamic_parameters`（扩充） | 未计算的 CORR 模板互判：不同输入图判异、拷贝判同；DROPNA 节点不合并（固化上游既有行为） | PASS |
| `test_FACTOR_alike_uses_factor_identity` | FACTOR 按“名称 + K线类型”判等；异名因子判异；同名同 KType 判同；同名不同 KType 判异 | PASS |
| `test_FactorSet_compiled_values_keep_nested_factors_distinct` | 嵌套 FACTOR 节点在 compiled 路径保持区分，逐值对齐独立计算与 legacy | PASS |

### 定向回归

| filter | cases | assertions | 结果 |
|--------|------:|-----------:|------|
| `test_CompiledFactorPlan*,test_FactorSet_compiled*,test_FactorSet_formula*,test_FACTOR*,test_indicator_alike*` | 46 | 5762 | PASS |

### 完整回归测试

```text
test cases:    778 |    778 passed | 0 failed | 0 skipped
assertions: 208593 | 208593 passed | 0 failed
```

## 改动范围

| 文件 | 类型 | 说明 |
|------|------|------|
| `hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp` | 修改 | `alike` 重排；动态参数叶子防御性 buffer 预尺寸 |
| `hikyuu_cpp/hikyuu/indicator/IndicatorImp.h` | 修改 | `supportBatchReuse` 契约文档 |
| `hikyuu_cpp/hikyuu/indicator/imp/IFactor.cpp` | 修改 | 启用 self-alike，按 Factor 唯一标识（名称 + K线类型）判等 |
| `hikyuu_cpp/hikyuu/factor/FactorSet.cpp` | 修改 | 嵌套调用 work-stealing 注释 |
| `hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.{h,cpp}` | 修改 | Author 头 |
| `hikyuu_cpp/unit_test/hikyuu/factor/test_FactorSet.cpp` | 修改 | 嵌套因子区分测试 |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_FACTOR.cpp` | 修改 | FACTOR 判等语义测试 |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_Indicator.cpp` | 修改 | CORR 模板结构等价、DROPNA 固化测试 |

合计：9 文件，+93 / -10，单提交。

## 性能影响

无数值算法与计算路径变化。`alike` 仅调整比较顺序；buffer 预尺寸位于当前无实例
命中的防御分支，不产生额外开销。

## 已知局限

**`IFactor` 按 Factor 唯一标识判等，依赖 FactorSet 的入口约束。** `Factor.h` 明确
“因子名称 + K线类型”为唯一标识，因此 `IFactor::selfAlike` 同时比较 `name` 和
`ktype`，而不递归比较公式内容。`FactorSet::add` 会先校验 K线类型一致，再按名字去重
（后加入者覆盖先加入者），所以结构良好的 FactorSet 中标识相同的嵌套因子只保留一份，
既符合 Factor 的身份语义，也能让多个外层公式正常共享同一因子节点。

边界：绕过 FactorSet 直接向 compiled 路径投喂“名称和 K线类型均相同、但公式不同”
的嵌套 FACTOR 时，这些节点仍会被视为同一因子并合并。如未来开放该入口，可在 Plan
构造期增加同标识公式一致性校验。
