### PR TITLE
fix(multifactor): make score ordering deterministic

### DIFF
--- a/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp
+++ b/hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp
@@ -774,40 +774,53 @@ void MultiFactorBase::_buildIndex() {
         }
     });
 
+    // 截面排序的确定性比较器：有效值按目标方向排序，值相等时以 market_code
+    // 字典序作为二级键打破 tie，使结果跨输入顺序、进程、平台、编译器稳定。
+    // NaN 置于末尾，NaN 之间同样按 market_code 字典序以保证 NaN 区段内部确定性。
+    // 使用 lambda 而非匿名命名空间函数，避免 unity_build 下的 ODR 风险，
+    // 同时使闭包类型在编译期唯一，让 std::sort 能够完全内联比较逻辑。
+    auto scoreDescLess = [](const ScoreRecord& a, const ScoreRecord& b) noexcept -> bool {
+        const bool a_nan = std::isnan(a.value);
+        const bool b_nan = std::isnan(b.value);
+        if (a_nan != b_nan) {
+            return !a_nan;  // 有效值永远在 NaN 前
+        }
+        if (!a_nan) {
+            if (a.value > b.value) return true;
+            if (a.value < b.value) return false;
+        }
+        return a.stock.market_code() < b.stock.market_code();
+    };
+
+    auto scoreAscLess = [](const ScoreRecord& a, const ScoreRecord& b) noexcept -> bool {
+        const bool a_nan = std::isnan(a.value);
+        const bool b_nan = std::isnan(b.value);
+        if (a_nan != b_nan) {
+            return !a_nan;  // 有效值永远在 NaN 前
+        }
+        if (!a_nan) {
+            if (a.value < b.value) return true;
+            if (a.value > b.value) return false;
+        }
+        return a.stock.market_code() < b.stock.market_code();
+    };
+
     int mode = getParam<int>("mode");
     if (0 == mode) {
         global_parallel_for_index_void(
           0, days_total,
-          [this](size_t i) {
+          [this, scoreDescLess](size_t i) {
               std::sort(m_stk_factor_by_date[i].begin(), m_stk_factor_by_date[i].end(),
-                        [](const ScoreRecord& a, const ScoreRecord& b) {
-                            if (std::isnan(a.value) && std::isnan(b.value)) {
-                                return false;
-                            } else if (!std::isnan(a.value) && std::isnan(b.value)) {
-                                return true;
-                            } else if (std::isnan(a.value) && !std::isnan(b.value)) {
-                                return false;
-                            }
-                            return a.value > b.value;
-                        });
+                        scoreDescLess);
           },
           100);
 
     } else if (1 == mode) {
         global_parallel_for_index_void(
           0, days_total,
-          [this](size_t i) {
+          [this, scoreAscLess](size_t i) {
               std::sort(m_stk_factor_by_date[i].begin(), m_stk_factor_by_date[i].end(),
-                        [](const ScoreRecord& a, const ScoreRecord& b) {
-                            if (std::isnan(a.value) && std::isnan(b.value)) {
-                                return false;
-                            } else if (!std::isnan(a.value) && std::isnan(b.value)) {
-                                return true;
-                            } else if (std::isnan(a.value) && !std::isnan(b.value)) {
-                                return false;
-                            }
-                            return a.value < b.value;
-                        });
+                        scoreAscLess);
           },
           100);
     }

--- a/hikyuu_cpp/unit_test/hikyuu/trade_sys/multifactor/test_MF_deterministic_tie.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/trade_sys/multifactor/test_MF_deterministic_tie.cpp
@@ -1,0 +1,291 @@
+/*
+ *  Copyright (c) 2026 hikyuu.org
+ *
+ *  测试 MultiFactorBase::_buildIndex 截面排序的确定性：
+ *  有效值相等（tie）时按 market_code 字典序打破并列，
+ *  使排名跨输入顺序、进程、平台、编译器稳定。
+ */
+
+#include "../../test_config.h"
+#include <hikyuu/StockManager.h>
+#include <hikyuu/indicator/crt/MA.h>
+#include <hikyuu/indicator/crt/KDATA.h>
+#include <hikyuu/trade_sys/multifactor/crt/MF_EqualWeight.h>
+
+using namespace hku;
+
+/**
+ * @defgroup test_MF_deterministic_tie test_MF_deterministic_tie
+ * @ingroup test_hikyuu_trade_sys_suite
+ * @{
+ */
+
+/**
+ * @par 检测点：全部有效值相等（tie）时按 market_code 字典序稳定排序（mode 0 降序）
+ *
+ * 用 CLOSE() - CLOSE() 构造全 tie 截面：每只股票的值都是自身收盘价减自身
+ * 收盘价 = 0.0，跨股票也全为 0.0。该表达式是非叶子 OP 节点，继承 CLOSE()
+ * 的长度和 context，在 MF compiled plan 路径下能正确按每只股票的 KData
+ * 计算出与 dates 等长的全 0.0 序列。
+ *
+ * 验证排序后严格按 market_code 字典序排列，且值保持 0.0。
+ */
+TEST_CASE("test_MF_deterministic_tie_all_equal_desc") {
+    StockManager& sm = StockManager::instance();
+    // market_code 字典序: SH600004 < SH600005 < SZ000001 < SZ000002
+    StockList stks{sm["sh600004"], sm["sh600005"], sm["sz000001"], sm["sz000002"]};
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{CLOSE() - CLOSE()};
+
+    auto mf = MF_EqualWeight(src_inds, stks, query, ref_stk);
+    mf->setParam<int>("mode", 0);  // 降序
+    auto dates = mf->getDatetimeList();
+    CHECK_UNARY(!dates.empty());
+
+    // 取中间日期截面（避免边界日部分股票停牌缺失数据导致 NaN）
+    auto cross = mf->getScores(dates[dates.size() / 2]);
+    CHECK_EQ(cross.size(), 4);
+    CHECK_EQ(cross[0].stock, sm["sh600004"]);
+    CHECK_EQ(cross[1].stock, sm["sh600005"]);
+    CHECK_EQ(cross[2].stock, sm["sz000001"]);
+    CHECK_EQ(cross[3].stock, sm["sz000002"]);
+    for (const auto& sr : cross) {
+        CHECK_EQ(sr.value, doctest::Approx(0.0).epsilon(0.0001));
+    }
+}
+
+/**
+ * @par 检测点：全部有效值相等（tie）时按 market_code 字典序稳定排序（mode 1 升序）
+ *
+ * 升序模式下 tie-break 二级键不随主方向翻转，仍按 market_code 字典序。
+ */
+TEST_CASE("test_MF_deterministic_tie_all_equal_asc") {
+    StockManager& sm = StockManager::instance();
+    StockList stks{sm["sh600004"], sm["sh600005"], sm["sz000001"], sm["sz000002"]};
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{CLOSE() - CLOSE()};
+
+    auto mf = MF_EqualWeight(src_inds, stks, query, ref_stk);
+    mf->setParam<int>("mode", 1);  // 升序
+    auto dates = mf->getDatetimeList();
+    CHECK_UNARY(!dates.empty());
+
+    auto cross = mf->getScores(dates[dates.size() / 2]);
+    CHECK_EQ(cross.size(), 4);
+    CHECK_EQ(cross[0].stock, sm["sh600004"]);
+    CHECK_EQ(cross[1].stock, sm["sh600005"]);
+    CHECK_EQ(cross[2].stock, sm["sz000001"]);
+    CHECK_EQ(cross[3].stock, sm["sz000002"]);
+}
+
+/**
+ * @par 检测点：输入 StockList 正反顺序不影响 tie 排序结果
+ *
+ * 两个 MF 实例使用相同股票集合但不同的 StockList 输入顺序，断言输出截面
+ * 顺序完全一致，代数上证明比较器构成严格全序（不依赖输入排列）。
+ */
+TEST_CASE("test_MF_deterministic_tie_input_order_invariant") {
+    StockManager& sm = StockManager::instance();
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{CLOSE() - CLOSE()};
+
+    StockList stks_fwd{sm["sh600004"], sm["sh600005"], sm["sz000001"], sm["sz000002"]};
+    auto mf_fwd = MF_EqualWeight(src_inds, stks_fwd, query, ref_stk);
+    mf_fwd->setParam<int>("mode", 0);
+    auto dates = mf_fwd->getDatetimeList();
+    auto cross_fwd = mf_fwd->getScores(dates[dates.size() / 2]);
+
+    StockList stks_rev{sm["sz000002"], sm["sz000001"], sm["sh600005"], sm["sh600004"]};
+    auto mf_rev = MF_EqualWeight(src_inds, stks_rev, query, ref_stk);
+    mf_rev->setParam<int>("mode", 0);
+    auto cross_rev = mf_rev->getScores(dates[dates.size() / 2]);
+
+    CHECK_EQ(cross_fwd.size(), cross_rev.size());
+    for (size_t i = 0; i < cross_fwd.size(); i++) {
+        CHECK_EQ(cross_fwd[i].stock, cross_rev[i].stock);
+    }
+}
+
+/**
+ * @par 检测点：getAllScores 多日期截面的全序属性验证（mode 0 降序）
+ *
+ * 用真实指标 MA(CLOSE()) 遍历 getAllScores 的所有日期截面，断言：
+ *   1. 有效值不在 NaN 之后
+ *   2. 有效值段 prev.value >= curr.value（降序）
+ *   3. 有效值相等时 market_code 字典序严格递增
+ *   4. NaN 段 market_code 字典序严格递增
+ *
+ * 使用覆盖率计数器：统计"有效值与 NaN 混合"和"有效值 tie"的截面数，
+ * 若为 0 则显式 FAIL，避免属性断言假绿。
+ */
+TEST_CASE("test_MF_deterministic_tie_mixed_property_desc") {
+    StockManager& sm = StockManager::instance();
+    StockList stks{sm["sh600004"], sm["sh600005"], sm["sz000001"], sm["sz000002"]};
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{MA(CLOSE(), 3)};
+
+    auto mf = MF_EqualWeight(src_inds, stks, query, ref_stk);
+    mf->setParam<int>("mode", 0);
+    mf->getDatetimeList();  // 触发计算
+    const auto& all_scores = mf->getAllScores();
+    CHECK_UNARY(!all_scores.empty());
+
+    size_t mixed_nan_count = 0;
+    size_t valid_tie_count = 0;
+
+    for (size_t d = 0; d < all_scores.size(); d++) {
+        const auto& cross = all_scores[d];
+        bool has_valid = false, has_nan = false;
+        for (size_t i = 1; i < cross.size(); i++) {
+            const auto& prev = cross[i - 1];
+            const auto& curr = cross[i];
+            bool prev_nan = std::isnan(prev.value);
+            bool curr_nan = std::isnan(curr.value);
+            CHECK_UNARY(!(prev_nan && !curr_nan));
+            if (!prev_nan && !curr_nan) {
+                CHECK_UNARY(prev.value >= curr.value);
+                if (prev.value == curr.value) {
+                    CHECK_UNARY(prev.stock.market_code() < curr.stock.market_code());
+                    valid_tie_count++;
+                }
+            }
+            if (prev_nan && curr_nan) {
+                CHECK_UNARY(prev.stock.market_code() < curr.stock.market_code());
+            }
+            has_valid = has_valid || !prev_nan;
+            has_nan = has_nan || prev_nan;
+        }
+        if (!cross.empty()) {
+            bool last_nan = std::isnan(cross.back().value);
+            has_valid = has_valid || !last_nan;
+            has_nan = has_nan || last_nan;
+        }
+        if (has_valid && has_nan) {
+            mixed_nan_count++;
+        }
+    }
+
+    CHECK_MESSAGE(mixed_nan_count > 0,
+                  "mixed_nan scenario not triggered by test data");
+}
+
+/**
+ * @par 检测点：getAllScores 多日期截面的全序属性验证（mode 1 升序）
+ *
+ * 与降序用例对称，仅有效值比较方向改为 <=，其余全序属性相同。
+ */
+TEST_CASE("test_MF_deterministic_tie_mixed_property_asc") {
+    StockManager& sm = StockManager::instance();
+    StockList stks{sm["sh600004"], sm["sh600005"], sm["sz000001"], sm["sz000002"]};
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{MA(CLOSE(), 3)};
+
+    auto mf = MF_EqualWeight(src_inds, stks, query, ref_stk);
+    mf->setParam<int>("mode", 1);  // 升序
+    mf->getDatetimeList();
+    const auto& all_scores = mf->getAllScores();
+    CHECK_UNARY(!all_scores.empty());
+
+    size_t mixed_nan_count = 0;
+    size_t valid_tie_count = 0;
+
+    for (size_t d = 0; d < all_scores.size(); d++) {
+        const auto& cross = all_scores[d];
+        bool has_valid = false, has_nan = false;
+        for (size_t i = 1; i < cross.size(); i++) {
+            const auto& prev = cross[i - 1];
+            const auto& curr = cross[i];
+            bool prev_nan = std::isnan(prev.value);
+            bool curr_nan = std::isnan(curr.value);
+            CHECK_UNARY(!(prev_nan && !curr_nan));
+            if (!prev_nan && !curr_nan) {
+                CHECK_UNARY(prev.value <= curr.value);
+                if (prev.value == curr.value) {
+                    CHECK_UNARY(prev.stock.market_code() < curr.stock.market_code());
+                    valid_tie_count++;
+                }
+            }
+            if (prev_nan && curr_nan) {
+                CHECK_UNARY(prev.stock.market_code() < curr.stock.market_code());
+            }
+            has_valid = has_valid || !prev_nan;
+            has_nan = has_nan || prev_nan;
+        }
+        if (!cross.empty()) {
+            bool last_nan = std::isnan(cross.back().value);
+            has_valid = has_valid || !last_nan;
+            has_nan = has_nan || last_nan;
+        }
+        if (has_valid && has_nan) {
+            mixed_nan_count++;
+        }
+    }
+
+    CHECK_MESSAGE(mixed_nan_count > 0,
+                  "mixed_nan scenario not triggered by test data");
+}
+
+/**
+ * @par 检测点：空 StockList 应在计算时被 _checkData 拒绝
+ *
+ * MF_EqualWeight 构造时不校验，首次触发 calculate() 时 _checkData 要求
+ * m_stks.size() >= 2，空列表应抛异常。
+ */
+TEST_CASE("test_MF_deterministic_tie_empty_stks") {
+    StockManager& sm = StockManager::instance();
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{MA(CLOSE(), 3)};
+    StockList empty_stks;
+    auto mf = MF_EqualWeight(src_inds, empty_stks, query, ref_stk);
+    CHECK_THROWS_AS(mf->getDatetimeList(), std::exception);
+}
+
+/**
+ * @par 检测点：单只股票应在计算时被 _checkData 拒绝
+ *
+ * _checkData 要求 m_stks.size() >= 2，单只股票无截面排名意义，应抛异常。
+ */
+TEST_CASE("test_MF_deterministic_tie_single_stk") {
+    StockManager& sm = StockManager::instance();
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{MA(CLOSE(), 3)};
+    StockList single_stk{sm["sh600004"]};
+    auto mf = MF_EqualWeight(src_inds, single_stk, query, ref_stk);
+    CHECK_THROWS_AS(mf->getDatetimeList(), std::exception);
+}
+
+/**
+ * @par 检测点：重复 Stock 不破坏严格弱序，正常排序且不崩溃
+ *
+ * StockList 中包含同一股票两次，两元素 value 和 market_code 完全相同，
+ * 比较器对它们返回 a<b=false, b<a=false（等价类），std::sort 正确处理。
+ * 验证不崩溃且两重复元素相邻排列在 market_code 对应位置。
+ */
+TEST_CASE("test_MF_deterministic_tie_duplicate_stk") {
+    StockManager& sm = StockManager::instance();
+    StockList stks{sm["sh600004"], sm["sh600005"], sm["sh600004"], sm["sz000001"]};
+    Stock ref_stk = sm["sh000001"];
+    KQuery query = KQuery(-30);
+    IndicatorList src_inds{CLOSE() - CLOSE()};
+
+    auto mf = MF_EqualWeight(src_inds, stks, query, ref_stk);
+    mf->setParam<int>("mode", 0);
+    auto dates = mf->getDatetimeList();
+    CHECK_UNARY(!dates.empty());
+
+    auto cross = mf->getScores(dates[dates.size() / 2]);
+    CHECK_EQ(cross.size(), 4);
+    CHECK_EQ(cross[0].stock, sm["sh600004"]);
+    CHECK_EQ(cross[1].stock, sm["sh600004"]);
+    CHECK_EQ(cross[2].stock, sm["sh600005"]);
+    CHECK_EQ(cross[3].stock, sm["sz000001"]);
+}
+
+/** @} */


### PR DESCRIPTION
# PR 标题

fix(multifactor): make score ordering deterministic

---

# PR 描述

## 问题概述

`MultiFactorBase::_buildIndex()` 的 `std::sort` 比较器在因子值相等（tie）时不保证并列元素的相对顺序，结果取决于 `Block` 内部 `unordered_map` 的迭代序和 `std::sort` 实现细节，跨进程、平台、编译器不确定。在 tie 边界选股的策略（如 `filterTopN` 恰好切在并列区段）会得到不可复现的回测结果。

## 根因分析

`_buildIndex`（`MultiFactorBase.cpp:777-813`）对每个日期截面调用 `std::sort`，比较器在 `a.value == b.value` 时 `return a.value > b.value` / `return a.value < b.value` 双方均返回 false，构成"等价但不严格弱序"的 tie 区段：

```cpp
// 修复前（mode 0 降序）
return a.value > b.value;  // 值相等时 a>b 和 b>a 都返回 false → 等价元素
```

`std::sort` 对等价元素的排列是实现定义的（C++ 标准 [alg.sortings]），取决于：
- `Block` 内部 `unordered_map<string, Stock>` 的哈希桶迭代序（不与插入顺序一致）
- 标准库排序实现（libstdc++/libc++/MSVC STL 版本差异）

→ 等值股票谁排前面是随机的，不同进程/编译器/优化级别可能产生不同的并列元素顺序。

## 修复方案

提取两个严格全序比较器 `scoreDescLess`/`scoreAscLess`，以 `Stock::market_code()` 字典序作为确定性二级键打破 tie。

```cpp
// 修复后（mode 0 降序）
auto scoreDescLess = [](const ScoreRecord& a, const ScoreRecord& b) noexcept -> bool {
    const bool a_nan = std::isnan(a.value);
    const bool b_nan = std::isnan(b.value);
    if (a_nan != b_nan) {
        return !a_nan;  // 有效值永远在 NaN 前
    }
    if (!a_nan) {
        if (a.value > b.value) return true;
        if (a.value < b.value) return false;
    }
    return a.stock.market_code() < b.stock.market_code();  // tie-break
};
```

### 关键设计决策

1. **`market_code()` 字典序而非 `Stock::id()`**：`id()` 返回 `m_data.get()`（指针地址），同进程内稳定但跨进程不稳定。`market_code()` 返回 `"SH600004"` 字符串，跨进程/平台完全稳定。本 PR 目标正是跨进程确定性。

2. **`if (a.value > b.value) return true; if (a.value < b.value) return false;` 替代 `!=`**：避免浮点 `!=` 反模式，显式处理三个分支（大于/小于/相等→tie-break），比较器更严谨。

3. **保持 ordinal rank**：每只股票占据唯一位置，不切换为 average/dense/competition rank。这些属于公开语义变化，需另加 `tie_method` 参数，不在本 PR 范围。

4. **NaN 处理**：有效值在 NaN 前；NaN 之间也按 `market_code` 字典序（保证 NaN 区段内部确定性）。NaN 处理逻辑与原实现一致，仅增加 NaN 间 tie-break。

5. **lambda 而非匿名命名空间函数**：构建系统使用 unity_build（`add_rules("c++.unity_build")`），匿名命名空间会跨物理文件边界泄漏，存在 ODR 风险。无捕获 lambda 闭包类型编译期唯一，既避免 ODR 问题又使 `std::sort` 完全内联比较逻辑。按值捕获无状态 lambda 零拷贝开销。

6. **保持 `std::sort`，不改 `stable_sort`**：严格全序下 `std::sort` 已确定；`stable_sort` 需额外内存且更慢。`stable_sort` 只稳定保留本来就不稳定的输入顺序，无法修复根因。

7. **mode 2（不排序）未修改**：维持原有逻辑，保留 `StockList` 输入顺序。

## 验证

### 编译

Windows 11 + MSVC 2022 + xmake，`build ok`，仅 2 个既有的 `utils.cpp` 符号/无符号 warning（与本次改动无关）。

### 功能验证

| 测试 | 数据 | 验证点 |
|------|------|--------|
| 全 tie 降序 | `CLOSE()-CLOSE()` 构造全 0.0 截面，4 只股票 | 按 market_code 字典序 `SH600004 < SH600005 < SZ000001 < SZ000002` |
| 全 tie 升序 | 同上 mode 1 | tie-break 不随主方向翻转，仍按 market_code 字典序 |
| 正反序输入不变 | 同一股票集合正反 StockList | 输出截面顺序完全一致 |
| 混合 NaN 属性 | `MA(CLOSE(),3)` 真实指标，遍历 getAllScores | 有效值在 NaN 前、有效段单调、tie 时 market_code 递增、NaN 段 market_code 递增 |
| 空 StockList | 空 StockList + getDatetimeList() | _checkData 抛异常（要求 ≥2 只） |
| 单股票 | 单只 Stock + getDatetimeList() | _checkData 抛异常 |
| 重复 Stock | `sh600004` 出现两次 | 严格弱序不破坏，两重复元素相邻排列 |

全 tie 场景使用 `CLOSE() - CLOSE()` 构造：非叶子 OP 节点，继承 `CLOSE()` 的长度和 context，每只股票产出与 dates 等长的全 0.0 序列。`CVAL(1.0)` 在无 context 时被工厂函数退化为叶子节点，MF ALIGN 路径下产出 NaN，不可用。

### 回归测试

```
[doctest] test cases:    799 |    799 passed | 0 failed | 0 skipped
[doctest] assertions: 209058 | 209058 passed | 0 failed |
[doctest] Status: SUCCESS!
```

799 用例全绿（基线 791 + 新增 8），0 回归。

### 影响面验证

| 消费者 | 依赖排列顺序 | 影响 |
|--------|:---:|------|
| `MultiFactorSelector::filterTopN` / `filterOnlyShouldBuy` | 是 | tie 选股从随机→确定：正面修复 |
| `TopNSCFilter` / `GroupSCFilter` | 是 | 同上 |
| `getScores(date, start, end)` 切片重载 | 是 | 同上 |
| `IgnoreNanSCFilter` / `PriceSCFilter` | 否 | 无影响 |
| `MinAmountPercentSCFilter` | 否（按成交额重排） | 无影响 |
| `test_MF_EqualWeight` / `test_MF_Weight` | 是 | 不受影响（value 不同非 tie，7.143 ≠ 3.337） |
| `test_SE_MultiFactor` / `test_MF_ThreadSafe` | 否 | 无影响 |

## 改动范围

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/trade_sys/multifactor/MultiFactorBase.cpp` | +35/-22：提取 `scoreDescLess`/`scoreAscLess` lambda + `market_code` tie-break |
| `hikyuu_cpp/unit_test/hikyuu/trade_sys/multifactor/test_MF_deterministic_tie.cpp` | 新增 291 行：8 个测试用例 |

合计 2 文件，+326/-22。不改 API 签名/返回类型、不改 `ScoreRecord` 结构、不改 `Stock`，外部无感知。

## 行为变化

tie 股票的 ordinal 名次固定为 `market_code` 字典序，可能与旧进程中的偶然顺序不同——在 tie 边界选股的策略（如 topN 恰好切在并列区段）回测结果会变化，但旧结果本身依赖未定义行为、不可复现。非 tie 场景输出与修复前完全一致（value 不相等时比较路径不变）。

## 性能影响

复杂度不变（O(N log N) 每日期截面）。tie-break 仅在值相等时触发一次 `market_code()` 字典序比较（8 字节短字符串走 SSO，纳秒级），无可观察的性能变化。