### PR TITLE
feat(indicator): add origin-id for cache identity

### DIFF
--- a/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
+++ b/hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp
@@ -32,6 +32,7 @@ IndicatorImpPtr CompiledFactorPlan::cloneNode(const IndicatorImpPtr& src, CloneM
 
     dst->m_params = src->m_params;
     dst->m_name = src->m_name;
+    dst->m_origin_id = src->m_origin_id;  // 出身证复印：与 IndicatorImp::clone() 语义一致
     dst->m_is_python_object = src->m_is_python_object;
     dst->m_need_self_alike_compare = src->m_need_self_alike_compare;
     dst->m_is_serial = src->m_is_serial;

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -6,6 +6,7 @@
  */
 #include <stdexcept>
 #include <algorithm>
+#include <atomic>
 #include <forward_list>
 #include <stack>
 #include "hikyuu/utilities/Log.h"
@@ -145,6 +146,14 @@ HKU_API std::ostream &operator<<(std::ostream &os, const IndicatorImpPtr &imp) {
         os << imp->str();
     }
     return os;
+}
+
+// 构造出身发号器。唯一定义于本文件（非 inline），保证跨 DLL 只有一份计数器：
+// 派生指标可能在插件 dll（如 extind）中构造，但其基类构造函数由核心 dll 导出并执行，
+// in-class 初始器随之在核心侧求值，id 空间统一。
+uint64_t IndicatorImp::nextOriginId() noexcept {
+    static std::atomic<uint64_t> seq{1};
+    return seq.fetch_add(1, std::memory_order_relaxed);
 }
 
 IndicatorImp::IndicatorImp() : m_name("IndicatorImp") {
@@ -398,6 +407,7 @@ IndicatorImpPtr IndicatorImp::clone() {
     IndicatorImpPtr p = _clone();
     p->m_params = m_params;
     p->m_name = m_name;
+    p->m_origin_id = m_origin_id;  // 出身证复印：克隆链共享构造身份
     p->m_is_python_object = m_is_python_object;
     p->m_need_self_alike_compare = m_need_self_alike_compare;
     p->m_is_serial = m_is_serial;

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp
@@ -156,6 +156,10 @@ uint64_t IndicatorImp::nextOriginId() noexcept {
     return seq.fetch_add(1, std::memory_order_relaxed);
 }
 
+uint64_t IndicatorImp::originId() const noexcept {
+    return m_origin_id;
+}
+
 IndicatorImp::IndicatorImp() : m_name("IndicatorImp") {
     memset(m_pBuffer, 0, sizeof(buffer_t *) * MAX_RESULT_NUM);
 }

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
@@ -130,6 +130,16 @@ public:
     /** 返回形如：Name(param1=val,param2=val,...) */
     string long_name() const;
 
+    /**
+     * @brief 构造出身标识（进程内唯一，clone/cloneNode 传承，不序列化）
+     *
+     * 供缓存类设施用作身份（如截面面板缓存）。同一次构造及其克隆链共享同一 id；
+     * 独立构造必然不同 id。不参与 alike()/operator==/formula() 等任何既有判等与展示。
+     */
+    uint64_t originId() const noexcept {
+        return m_origin_id;
+    }
+
     virtual string formula() const;
     virtual string str() const;
 
@@ -341,6 +351,12 @@ protected:
     ind_param_map_t m_ind_params;  // don't use unordered_map
 
     IndicatorImp* m_parent{nullptr};  // can't use shared_from_this in python, so not weak_ptr
+
+    /** 构造发号器：唯一定义在 IndicatorImp.cpp，保证跨 DLL 只有一份计数器 */
+    static uint64_t nextOriginId() noexcept;
+
+    /** 构造出身标识：构造发放，clone/cloneNode 传承，不进序列化 NVP 列表 */
+    uint64_t m_origin_id{nextOriginId()};
 
 public:
     static void initEngine();

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
@@ -135,10 +135,11 @@ public:
      *
      * 供缓存类设施用作身份（如截面面板缓存）。同一次构造及其克隆链共享同一 id；
      * 独立构造必然不同 id。不参与 alike()/operator==/formula() 等任何既有判等与展示。
+     *
+     * 注：定义在 IndicatorImp.cpp（非 inline）。dllexport 类的 inline 成员不保证导出，
+     * 是否产生外部符号引用取决于调用方的内联决策，插件 dll 会链接失败。
      */
-    uint64_t originId() const noexcept {
-        return m_origin_id;
-    }
+    uint64_t originId() const noexcept;
 
     virtual string formula() const;
     virtual string str() const;

--- a/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
+++ b/hikyuu_cpp/hikyuu/indicator/IndicatorImp.h
@@ -138,6 +138,10 @@ public:
      *
      * 注：定义在 IndicatorImp.cpp（非 inline）。dllexport 类的 inline 成员不保证导出，
      * 是否产生外部符号引用取决于调用方的内联决策，插件 dll 会链接失败。
+     *
+     * 注意（身份语义限制）：origin_id 只标识"出身"，不感知构造后的原地变异
+     * （setParam/setIndParam/add）。凡被缓存设施用作身份的指标对象，构造后必须
+     * 视为不可变；如需不同参数请构造新对象（新对象必持新 id）。
      */
     uint64_t originId() const noexcept;
 

--- a/hikyuu_cpp/unit_test/hikyuu/indicator/test_IndicatorOriginId.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/indicator/test_IndicatorOriginId.cpp
@@ -1,0 +1,115 @@
+/*
+ * test_IndicatorOriginId.cpp
+ *
+ *  Created on: 2026-08-12
+ *      Author: woleigegg
+ *
+ *  origin_id（构造出身标识）专项测试：
+ *  构造即唯一、clone 传承、序列化 load 持新号。
+ *  注：CompiledFactorPlan::cloneNode 的传承（同一行拷贝语义）为 private static 路径，
+ *  无公共探针，由代码审查覆盖；此处验证公共可断言的不变量。
+ */
+
+#include "../test_config.h"
+#include <fstream>
+#include <hikyuu/indicator/crt/MA.h>
+#include <hikyuu/indicator/crt/REF.h>
+#include <hikyuu/indicator/crt/CVAL.h>
+#include <hikyuu/indicator/crt/KDATA.h>
+
+#if HKU_SUPPORT_SERIALIZATION
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#endif
+
+using namespace hku;
+
+/**
+ * @defgroup test_indicator_OriginId test_indicator_OriginId
+ * @ingroup test_hikyuu_indicator_suite
+ * @{
+ */
+
+static uint64_t origin_id_of(const Indicator& ind) {
+    return ind.getImp()->originId();
+}
+
+/** @par 检测点：独立构造必然不同号（公式碰撞类 bug 的根治基础） */
+TEST_CASE("test_IndicatorOriginId_construct_unique") {
+    Indicator c = CLOSE(), o = OPEN(), h = HIGH();
+
+    // 同构不同参：B1 复现 bug 的全部代表族
+    CHECK_NE(origin_id_of(MA(c, 20)), origin_id_of(MA(c, 60)));
+    CHECK_NE(origin_id_of(REF(c, 1)), origin_id_of(REF(c, 5)));
+    CHECK_NE(origin_id_of(CVAL(1.0)), origin_id_of(CVAL(2.0)));
+    CHECK_NE(origin_id_of(CVAL(1.0)), origin_id_of(CVAL(1.0)));  // 同参独立构造也不同号
+
+    // 结构不同：括号歧义与同形异算符
+    CHECK_NE(origin_id_of((c + o) * h), origin_id_of(c + o * h));
+    CHECK_NE(origin_id_of(c + o), origin_id_of(c - o));
+
+    // 同一叶子对象被两棵树共享（菱形）时各自根节点仍独立
+    Indicator shared = c + o;
+    CHECK_NE(origin_id_of(shared * h), origin_id_of(shared + h));
+}
+
+/** @par 检测点：clone 传承（跨股票/批量路径缓存命中的前提） */
+TEST_CASE("test_IndicatorOriginId_clone_inherit") {
+    Indicator c = CLOSE(), o = OPEN(), h = HIGH();
+
+    Indicator f = MA(c, 20) + CVAL(1.0);
+    Indicator g = f.clone();
+    CHECK_EQ(origin_id_of(f), origin_id_of(g));
+
+    // 整树逐节点传承：根、左右子树、OP 节点的数据叶（MA(n)(ind) 经 operator() 挂为 m_right）
+    auto fp = f.getImp(), gp = g.getImp();
+    CHECK_EQ(fp->getLeftNode()->originId(), gp->getLeftNode()->originId());    // MA 子树
+    CHECK_EQ(fp->getRightNode()->originId(), gp->getRightNode()->originId());  // CVAL 子树
+    auto ma_l = fp->getLeftNode(), ma_g = gp->getLeftNode();
+    CHECK_EQ(ma_l->getRightNode()->originId(), ma_g->getRightNode()->originId());  // CLOSE 叶
+
+    // clone 的 clone 同号（克隆链）
+    Indicator e = g.clone();
+    CHECK_EQ(origin_id_of(f), origin_id_of(e));
+
+    // clone 后与独立构造仍不同号
+    CHECK_NE(origin_id_of(g), origin_id_of(MA(c, 20) + CVAL(1.0)));
+}
+
+#if HKU_SUPPORT_SERIALIZATION
+/** @par 检测点：反序列化持新号（origin_id 不入档，load 走默认构造发新号） */
+TEST_CASE("test_IndicatorOriginId_serialize_fresh") {
+    StockManager& sm = StockManager::instance();
+    string filename(sm.tmpdir());
+    filename += "/ORIGIN_ID.xml";
+
+    Indicator x1 = MA(CLOSE(), 20);
+    {
+        std::ofstream ofs(filename);
+        boost::archive::xml_oarchive oa(ofs);
+        oa << BOOST_SERIALIZATION_NVP(x1);
+    }
+
+    Indicator x2;
+    {
+        std::ifstream ifs(filename);
+        boost::archive::xml_iarchive ia(ifs);
+        ia >> BOOST_SERIALIZATION_NVP(x2);
+    }
+
+    // load 出的节点持本进程新号：与原对象、与现场新构的同公式对象均不同
+    CHECK_NE(origin_id_of(x2), origin_id_of(x1));
+    CHECK_NE(origin_id_of(x2), origin_id_of(MA(CLOSE(), 20)));
+
+    // 同一存档再次 load：又发新号，互不共享（安全方向）
+    Indicator x3;
+    {
+        std::ifstream ifs(filename);
+        boost::archive::xml_iarchive ia(ifs);
+        ia >> BOOST_SERIALIZATION_NVP(x3);
+    }
+    CHECK_NE(origin_id_of(x3), origin_id_of(x2));
+}
+#endif /* #if HKU_SUPPORT_SERIALIZATION */
+
+/** @} */


### PR DESCRIPTION

## 问题概述

指标缓存类设施需要一个稳定的指标身份（identity）作为缓存 key 成分，但核心目前没有可用的身份设施：

- `Indicator::formula()` 不含参数值——`MA(CLOSE,20)` 与 `MA(CLOSE,60)` 输出同为 `"MA(CLOSE)"`，以此为 key 会把同构不同参的公式错误合并；
- `alike()` 逐节点比较 `m_discard`、叶子节点比较完整 buffer 数据（`IndicatorImp.cpp:1974,1992-2002`）——这些是运行时派生状态而非公式身份：同一公式在不同股票上下文中计算后 `alike()` 判不等，用作缓存身份会导致缓存永不跨上下文命中；
- 指标完整身份所需的信息（私有成员如 `IIc::m_stks`、Python 对象逻辑）只在核心内部可见，核心之外的任何身份方案都无法完整覆盖。

## 根因分析

### 1. `formula()` 丢失参数值（`IndicatorImp.cpp:604-695`）

```cpp
case LEAF: buf << m_name; break;
case OP:   buf << m_name << "(" << m_right->formula() << ")"; break;
```

叶子只输出 `m_name`、单参算子不输出参数值 → 所有同构不同参公式（MA/REF/CVAL/EMA/…）共享同一字符串；括号结构同样丢失（`(C+O)*H` 与 `C+O*H` 同为 `"CLOSE + OPEN * HIGH"`）。

### 2. 身份信息所在层级

`IIc` 的股票池是私有成员（`IIc.h:26-27`，无公共 getter），`IContext::m_ref_ind` 同理；Python 自定义指标的计算逻辑在 pybind trampoline 之后不可内省。身份设施只能由核心提供。

### 3. `alike()` 的上下文残留陷阱

`clone()` 复制 buffer、`m_discard`、`m_context`（`IndicatorImp.cpp:397-417`），`setContext(KData())` 不清除（`:247+`）。`alike()` 把这些运行时残留当身份比较，语义上就不是缓存身份。

## 修复方案

给 `IndicatorImp` 增加**构造出身标识** `m_origin_id`：身份 = 出身（"是否同一次构造"），不读参数/类型/结构等任何内容。

1. **构造发号**：进程级 `std::atomic<uint64_t>` 计数器，唯一定义在 `IndicatorImp.cpp`（非 inline，保证跨 DLL 只有一份计数器）；NSDMI in-class 初始化覆盖全部构造路径，无需逐个构造函数添加。
2. **克隆传承（两条拷贝路径，缺一不可）**：

   | 路径 | 位置 | 说明 |
   |------|------|------|
   | `IndicatorImp::clone()` | `IndicatorImp.cpp:414` | per-stock `operator()(KData)` 深拷贝整树走此路 |
   | `CompiledFactorPlan::cloneNode()` | `factor/imp/CompiledFactorPlan.cpp:35` | 独立成员拷贝实现，不经过 `clone()` |

3. **不进序列化 NVP 列表**：boost 反序列化 = 默认构造（发新号）→ `load()` 不覆盖该成员 → load 出的节点天然持本进程新号，零代码。
4. **`originId()` out-of-line 定义**：dllexport 类的 inline 成员不保证导出（是否产生外部符号引用取决于调用方内联决策），在 .cpp 定义经类级 dllexport 稳定导出。
5. **纯附加元数据**：`alike()`/`operator==`/`formula()`/CSE **零接触**，无行为变化。

```cpp
uint64_t IndicatorImp::nextOriginId() noexcept {
    static std::atomic<uint64_t> seq{1};
    return seq.fetch_add(1, std::memory_order_relaxed);
}
```

语义：同一次构造及其克隆链共享同一 id（跨上下文/批量复用稳定）；独立构造必然不同 id（同构不同参、括号歧义、Python 对象、含私有状态节点天然区分，无需逐类型处理）。

## 验证

### 编译

Windows + MSVC 2022 + xmake：`hikyuu.dll` / `unit-test.exe` build ok。

### 功能验证（新增 `test_IndicatorOriginId.cpp`，3 用例 16 断言）

| 用例 | 验证点 |
|------|--------|
| `construct_unique` | MA20/MA60、REF1/REF5、CVAL(1)/CVAL(2)、同参独立构造、`(C+O)*H` vs `C+O*H`、`C+O` vs `C-O` —— origin_id 全部不同 |
| `clone_inherit` | clone 同号（根/左右子树/OP 数据叶三层核验）；clone 的 clone 同号；clone 后与独立构造仍不同号 |
| `serialize_fresh` | load 出的节点 ≠ 原对象、≠ 现场新构同公式对象；同一存档两次 load 互不等（安全方向） |

### 回归测试

完整套件：**753 cases / 211111 assertions / 0 failed**（`test_AGG_*`/`test_GROUP_*` 因本地数据缺失扩展 K 线按既有门控排除，与本 PR 无关）。

## 改动范围

| 文件 | 改动 |
|------|------|
| `hikyuu_cpp/hikyuu/indicator/IndicatorImp.h` | `originId()` 声明 + `nextOriginId()` 声明 + `m_origin_id` NSDMI（+21） |
| `hikyuu_cpp/hikyuu/indicator/IndicatorImp.cpp` | 两函数定义 + `clone()` 传承行 + `<atomic>`（+14） |
| `hikyuu_cpp/hikyuu/factor/imp/CompiledFactorPlan.cpp` | `cloneNode()` 传承行（+1） |
| `hikyuu_cpp/unit_test/hikyuu/indicator/test_IndicatorOriginId.cpp` | 新测试（+115） |

合计 4 文件，+151/-0。

## 性能影响

每次节点构造 +1 次 relaxed 原子自增（纳秒级）；无锁、无热路径影响、无新增共享状态。

## 已知局限与后续工作

1. **不感知构造后原地变异**（`setParam`/`setIndParam`/`add`）：origin_id 只标识出身。凡被缓存设施用作身份的指标对象，构造后必须视为不可变（已在 `originId()` 文档中注明）；需不同参数请构造新对象（必持新 id）。如需根治（参数代际），属独立 issue。
2. **ABI 联动**：`IndicatorImp` 新增一个 `uint64_t` 成员，核心 dll 与所有含派生指标的二进制模块必须同步重编（不新增 BOOST_CLASS_VERSION——该成员不在序列化流中，新旧存档双向兼容）。
3. **跨构造去重未做**：独立构造的相同公式持不同 id（保守方向，正确性无损）。如需"同公式文本共享身份"，可在本设施上追加结构指纹通道（typeid+optype+参数无损哈希+子树递归，`needSelfAlikeCompare`/Python 节点回退 origin_id）——独立后续 PR，届时须处理：算符节点全是基类裸实例（`Indicator.cpp:147-232`，optype 必入）、CVAL 遍布字面量公式需豁免、参数类型白名单。
4. `getResult()`/对齐回退等路径产生新号节点：保守 miss 方向，不影响正确性。
