### PR TITLE
fix(trade): 使用实际执行数量同步空头 Broker 订单

### DIFF
--- a/hikyuu_cpp/hikyuu/trade_manage/TradeManager.cpp
+++ b/hikyuu_cpp/hikyuu/trade_manage/TradeManager.cpp
@@ -1081,8 +1081,8 @@ TradeRecord TradeManager::sellShort(const Datetime& datetime, const Stock& stock
         list<OrderBrokerPtr>::const_iterator broker_iter = m_broker_list.begin();
         for (; broker_iter != m_broker_list.end(); ++broker_iter) {
             (*broker_iter)
-              ->sell(datetime, stock.market(), stock.code(), realPrice, number, stoploss, goalPrice,
-                     from, remark);
+              ->sell(datetime, stock.market(), stock.code(), realPrice, sell_num, stoploss,
+                     goalPrice, from, remark);
             if (datetime > m_broker_last_datetime) {
                 m_broker_last_datetime = datetime;
             }
@@ -1156,8 +1156,8 @@ TradeRecord TradeManager::buyShort(const Datetime& datetime, const Stock& stock,
         list<OrderBrokerPtr>::const_iterator broker_iter = m_broker_list.begin();
         for (; broker_iter != m_broker_list.end(); ++broker_iter) {
             (*broker_iter)
-              ->buy(datetime, stock.market(), stock.code(), realPrice, number, stoploss, goalPrice,
-                    from, remark);
+              ->buy(datetime, stock.market(), stock.code(), realPrice, real_number, stoploss,
+                    goalPrice, from, remark);
             if (datetime > m_broker_last_datetime) {
                 m_broker_last_datetime = datetime;
             }

--- a/hikyuu_cpp/unit_test/hikyuu/trade_manage/test_TradeManager.cpp
+++ b/hikyuu_cpp/unit_test/hikyuu/trade_manage/test_TradeManager.cpp
@@ -7,6 +7,7 @@
 
 #include "doctest/doctest.h"
 #include <hikyuu/StockManager.h>
+#include <hikyuu/trade_manage/OrderBrokerBase.h>
 #include <hikyuu/trade_manage/crt/TC_TestStub.h>
 #include <hikyuu/trade_manage/crt/TC_FixedA.h>
 #include <hikyuu/trade_manage/crt/crtTM.h>
@@ -16,6 +17,30 @@
 #include <boost/archive/xml_iarchive.hpp>
 
 using namespace hku;
+
+namespace {
+
+class CaptureOrderBroker final : public OrderBrokerBase {
+public:
+    void _buy(Datetime, const string&, const string&, price_t, double num, price_t, price_t,
+              SystemPart, const string&) override {
+        last_buy_num = num;
+        buy_count++;
+    }
+
+    void _sell(Datetime, const string&, const string&, price_t, double num, price_t, price_t,
+               SystemPart, const string&) override {
+        last_sell_num = num;
+        sell_count++;
+    }
+
+    double last_buy_num{0.0};
+    double last_sell_num{0.0};
+    size_t buy_count{0};
+    size_t sell_count{0};
+};
+
+}  // namespace
 
 /**
  * @defgroup test_TradeManager test_TradeManager
@@ -387,6 +412,28 @@ TEST_CASE("test_TradeManager_can_not_checkoutStock") {
 
     /** @arg 试图在最后交易日期前取出 */
     CHECK_EQ(tm->checkinStock(Datetime(199901010000), stock, 10.0, 200), false);
+}
+
+TEST_CASE("test_TradeManager_short_orders_use_executed_number") {
+    StockManager& sm = StockManager::instance();
+    Stock stock = sm.getStock("sh600000");
+    TradeManagerPtr tm = crtTM(Datetime(199901010000), 100000, TC_Zero());
+    auto broker = std::make_shared<CaptureOrderBroker>();
+    tm->setBrokerLastDatetime(Datetime(199901010000));
+    tm->regBroker(broker);
+
+    Datetime sell_datetime(199911170000);
+    CHECK_EQ(tm->borrowStock(sell_datetime, stock, 10.0, 100), true);
+    TradeRecord sell_record = tm->sellShort(sell_datetime, stock, 10.0, 200);
+    CHECK_EQ(sell_record.number, 100);
+    CHECK_EQ(broker->sell_count, 1);
+    CHECK_EQ(broker->last_sell_num, sell_record.number);
+
+    Datetime buy_datetime(199911180000);
+    TradeRecord buy_record = tm->buyShort(buy_datetime, stock, 10.0, MAX_DOUBLE);
+    CHECK_EQ(buy_record.number, 100);
+    CHECK_EQ(broker->buy_count, 1);
+    CHECK_EQ(broker->last_buy_num, buy_record.number);
 }
 
 /** @par 检测点 */


### PR DESCRIPTION
#### 关联 Issue

Fixes #501

#### 问题

空头请求被持仓约束裁剪后，本地账本使用实际执行数量，但 `OrderBroker` 仍收到原始请求数量。全量回补使用 `MAX_DOUBLE` 时，Broker 甚至会直接收到 `MAX_DOUBLE`。

#### 修改内容

- `TradeManager::sellShort` 通知 Broker 时由 `number` 改为 `sell_num`；
- `TradeManager::buyShort` 通知 Broker 时由 `number` 改为 `real_number`；
- 新增捕获 Broker 买卖数量的测试桩；
- 新增回归用例，同时覆盖超额卖空请求和 `MAX_DOUBLE` 全量回补。

#### 修复效果

外部 Broker、`TradeRecord`、现金和空头持仓现在使用同一个实际执行数量，不再出现外部订单与本地状态分叉。

#### 测试

```text
定向测试：
test cases: 1 passed / 0 failed
assertions: 7 passed / 0 failed

完整 C++ 单元测试：
test cases: 535 passed / 0 failed
assertions: 200407 passed / 0 failed
```

构建命令：

```bash
xmake -b unit-test
```

测试命令：

```bash
build/release/linux/x86_64/lib/unit-test \
  --test-case=test_TradeManager_short_orders_use_executed_number
build/release/linux/x86_64/lib/unit-test
```

#### 改动范围

- `hikyuu_cpp/hikyuu/trade_manage/TradeManager.cpp`
- `hikyuu_cpp/unit_test/hikyuu/trade_manage/test_TradeManager.cpp`

无接口变更、无序列化格式变更。
