### PR TITLE
fix(data): 修复 SQL 后端派生周期 K 线跨界聚合

### DIFF
--- a/hikyuu/data/common_clickhouse.py
+++ b/hikyuu/data/common_clickhouse.py
@@ -394,11 +394,11 @@ def update_extern_data(connect, market, code, data_type):
 
             base_record_list = []
             start_ix = x
-            ix_date = current_date
-            while start_ix < length_base_all and \
-                    ix_date >= last_start_date and ix_date <= last_end_date:
+            while start_ix < length_base_all:
+                ix_date = Datetime.from_timestamp_utc(base_list[start_ix][0] * 1000000).ymdhm
+                if ix_date < last_start_date or ix_date > last_end_date:
+                    break
                 base_record_list.append(base_list[start_ix])
-                ix_date = Datetime.from_timestamp_utc(base_list[start_ix][0]*1000000).ymdhm
                 start_ix += 1
 
             if not base_record_list:

--- a/hikyuu/data/common_mysql.py
+++ b/hikyuu/data/common_mysql.py
@@ -462,11 +462,11 @@ def update_extern_data(connect, market, code, data_type):
             # cur.close()
             base_record_list = []
             start_ix = x
-            ix_date = current_date
-            while start_ix < length_base_all and \
-                    ix_date >= last_start_date and ix_date <= last_end_date:
-                base_record_list.append(base_list[start_ix])
+            while start_ix < length_base_all:
                 ix_date = base_list[start_ix][0]
+                if ix_date < last_start_date or ix_date > last_end_date:
+                    break
+                base_record_list.append(base_list[start_ix])
                 start_ix += 1
 
             if not base_record_list:

--- a/hikyuu/test/test.py
+++ b/hikyuu/test/test.py
@@ -26,6 +26,7 @@ import Stoploss
 import ProfitGoal
 import Slippage
 import AllocateFunds
+import test_common_sql
 
 if __name__ == "__main__":
 
@@ -58,6 +59,7 @@ if __name__ == "__main__":
     suite.addTest(Slippage.suiteTestCrtSL())
 
     suite.addTest(AllocateFunds.suite())
+    suite.addTest(test_common_sql.suite())
 
     unittest.TextTestRunner(verbosity=2).run(suite)
     # unittest.main()

--- a/hikyuu/test/test_common_sql.py
+++ b/hikyuu/test/test_common_sql.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import patch
+
+from hikyuu import Datetime
+from hikyuu.data import common_clickhouse, common_mysql
+
+
+BASE_RECORDS = [
+    (202501310000, 10, 11, 9, 10.5, 100, 10),
+    (202502030000, 20, 21, 19, 20.5, 200, 20),
+]
+
+
+class FakeMySQLCursor:
+    def __init__(self, connect):
+        self.connect = connect
+        self.rows = []
+
+    def execute(self, sql):
+        if sql.strip().lower().startswith("select date, open"):
+            self.rows = self.connect.base_records
+
+    def executemany(self, sql, values):
+        self.connect.writes.append((sql, list(values)))
+
+    def __iter__(self):
+        return iter(self.rows)
+
+    def close(self):
+        pass
+
+
+class FakeMySQLConnect:
+    def __init__(self, base_records):
+        self.base_records = base_records
+        self.writes = []
+
+    def cursor(self):
+        return FakeMySQLCursor(self)
+
+    def commit(self):
+        pass
+
+
+class FakeClickHouseResult:
+    def __init__(self, rows):
+        self.result_rows = rows
+
+
+class FakeClickHouseConnect:
+    def __init__(self, base_records):
+        self.base_records = base_records
+
+    def query(self, _sql, settings=None):
+        return FakeClickHouseResult(self.base_records)
+
+
+class CommonSQLTest(unittest.TestCase):
+    @staticmethod
+    def fake_mysql_table(_connect, _market, _code, ktype):
+        return ktype
+
+    @staticmethod
+    def fake_clickhouse_table(_connect, market, code, ktype):
+        return (ktype, market, code)
+
+    def test_mysql_period_data_does_not_include_next_period(self):
+        connect = FakeMySQLConnect(BASE_RECORDS)
+
+        def fake_lastdatetime(_connect, table):
+            return BASE_RECORDS[-1][0] if table == "day" else None
+
+        with patch.object(common_mysql, "get_table", side_effect=self.fake_mysql_table), \
+                patch.object(common_mysql, "get_lastdatetime", side_effect=fake_lastdatetime):
+            common_mysql.update_extern_data(connect, "SH", "600000", "day")
+
+        month_rows = next(values for sql, values in connect.writes if "month" in sql)
+        self.assertEqual(
+            month_rows,
+            [
+                (202501310000, 10, 11, 9, 10.5, 100, 10),
+                (202502280000, 20, 21, 19, 20.5, 200, 20),
+            ],
+        )
+
+    def test_clickhouse_period_data_does_not_include_next_period(self):
+        timestamp_records = [
+            (Datetime(record[0]).timestamp_utc() // 1000000, *record[1:])
+            for record in BASE_RECORDS
+        ]
+        connect = FakeClickHouseConnect(timestamp_records)
+
+        def fake_lastdatetime(_connect, table):
+            return Datetime(BASE_RECORDS[-1][0]) if table[0] == "day" else None
+
+        with patch.object(
+                common_clickhouse, "get_table", side_effect=self.fake_clickhouse_table
+        ), patch.object(
+                common_clickhouse, "get_lastdatetime", side_effect=fake_lastdatetime
+        ):
+            index_data = common_clickhouse.update_extern_data(connect, "SH", "600000", "day")
+
+        month_rows = index_data["month"]
+        self.assertEqual(
+            month_rows,
+            [
+                (
+                    "SH",
+                    "600000",
+                    Datetime(202501310000).timestamp_utc() // 1000000,
+                    10,
+                    11,
+                    9,
+                    10.5,
+                    100,
+                    10,
+                ),
+                (
+                    "SH",
+                    "600000",
+                    Datetime(202502280000).timestamp_utc() // 1000000,
+                    20,
+                    21,
+                    19,
+                    20.5,
+                    200,
+                    20,
+                ),
+            ],
+        )
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(CommonSQLTest)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### 关联 Issue

Fixes #502

#### 问题

MySQL 和 ClickHouse 的派生周期 K 线循环使用滞后一条的日期做边界判断，导致每个周期额外包含下一周期首根基础 K 线。

#### 修改内容

- MySQL：在追加基础记录前读取 `base_list[start_ix][0]` 并检查周期边界；
- ClickHouse：在追加前把待处理时间戳转换为 `ymdhm` 并检查周期边界；
- 超出当前周期时立即退出，不再先追加越界记录；
- 新增纯内存 MySQL/ClickHouse 连接桩测试，覆盖 2025-01-31 到 2025-02-03 的跨月边界。

#### 修复效果

- 1 月月线只聚合 1 月记录；
- 2 月首条记录不会丢失，仍会进入 2 月月线；
- 同一个循环服务的其他日线和分钟派生周期同步修复。

#### 测试

修复前：

```text
test_clickhouse_period_data_does_not_include_next_period ... FAIL
test_mysql_period_data_does_not_include_next_period ... FAIL

1 月实际值：high=21, close=20.5, amount=300, volume=30
```

修复后：

```text
test_clickhouse_period_data_does_not_include_next_period ... ok
test_mysql_period_data_does_not_include_next_period ... ok
Ran 2 tests
OK
```

测试命令：

```bash
python -m unittest hikyuu.test.test_common_sql -v
PYTHONPATH=. python hikyuu/test/test.py
python -m py_compile \
  hikyuu/data/common_mysql.py \
  hikyuu/data/common_clickhouse.py \
  hikyuu/test/test_common_sql.py \
  hikyuu/test/test.py
```

此外，包含所有 C++ 用例的完整测试集为 535/535 通过、200407/200407 断言通过。

#### 改动范围

- `hikyuu/data/common_mysql.py`
- `hikyuu/data/common_clickhouse.py`
- `hikyuu/test/test_common_sql.py`
- `hikyuu/test/test.py`

无需数据库迁移，不改变表结构和公开接口。
